### PR TITLE
Overhaul XDM Value sequence handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,11 @@
 version: 2
 jobs:
-  test:
+  test_vendored_saxon:
     environment:
       BUNDLE_JOBS: 3
       BUNDLE_RETRY: 3
       BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
     docker:
       - image: circleci/jruby:9.2.8.0-jdk
     steps:
@@ -21,8 +22,41 @@ jobs:
       - store_artifacts:
           path: /tmp/test-results
           destination: test-results
+  test_saxon_98:
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      ALTERNATE_SAXON_HOME: /tmp/saxon
+      JRUBY_OPTS: "--dev --debug"
+    docker:
+      - image: circleci/jruby:9.2.8.0-jdk
+    steps:
+      - checkout
+      - run:
+          name: Download Saxon 9.8
+          command: |
+            mkdir /tmp/saxon
+            cd /tmp/saxon
+            curl -L -O https://sourceforge.net/projects/saxon/files/Saxon-HE/9.8/SaxonHE9-8-0-15J.zip
+            unzip SaxonHE9-8-0-15J.zip
+            rm -f SaxonHE9-8-0-15J.zip
+      - run:
+          name: Bundle Install
+          command: bundle check || bundle install
+      - run:
+          command: |
+            mkdir /tmp/test-results
+            bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results
+
 workflows:
   version: 2
   build_and_test:
     jobs:
-      - test
+      - test_vendored_saxon
+      - test_saxon_98

--- a/lib/saxon/axis_iterator.rb
+++ b/lib/saxon/axis_iterator.rb
@@ -1,5 +1,5 @@
 require_relative 's9api'
-require_relative 'xdm/node'
+require_relative 'xdm'
 
 module Saxon
   # An XPath Data Model Node object, representing an XML document, or an element or one of the other node chunks in the XDM.

--- a/lib/saxon/axis_iterator.rb
+++ b/lib/saxon/axis_iterator.rb
@@ -1,5 +1,5 @@
-require 'saxon/s9api'
-require 'saxon/xdm_node'
+require_relative 's9api'
+require_relative 'xdm/node'
 
 module Saxon
   # An XPath Data Model Node object, representing an XML document, or an element or one of the other node chunks in the XDM.
@@ -20,7 +20,7 @@ module Saxon
     end
 
     def each(&block)
-      s9_sequence_iterator.lazy.map { |s9_xdm_node| Saxon::XdmNode.new(s9_xdm_node) }.each(&block)
+      s9_sequence_iterator.lazy.map { |s9_xdm_node| Saxon::XDM::Node.new(s9_xdm_node) }.each(&block)
     end
 
     private

--- a/lib/saxon/axis_iterator.rb
+++ b/lib/saxon/axis_iterator.rb
@@ -1,5 +1,4 @@
 require_relative 's9api'
-require_relative 'xdm'
 
 module Saxon
   # An XPath Data Model Node object, representing an XML document, or an element or one of the other node chunks in the XDM.

--- a/lib/saxon/document_builder.rb
+++ b/lib/saxon/document_builder.rb
@@ -1,4 +1,4 @@
-require 'saxon/xdm_node'
+require 'saxon/xdm/node'
 
 module Saxon
   # Builds XDM objects from XML sources, for use in XSLT or for query and
@@ -13,10 +13,10 @@ module Saxon
 
     # @param [Saxon::Source] source The Saxon::Source containing the source
     #   IO/string
-    # @return [Saxon::XdmNode] The Saxon::XdmNode representing the root of the
+    # @return [Saxon::XDM::Node] The Saxon::XDM::Node representing the root of the
     #   document tree
     def build(source)
-      XdmNode.new(@s9_document_builder.build(source.to_java))
+      XDM::Node.new(@s9_document_builder.build(source.to_java))
     end
 
     # @return [net.sf.saxon.s9api.DocumentBuilder] The underlying Java Saxon

--- a/lib/saxon/document_builder.rb
+++ b/lib/saxon/document_builder.rb
@@ -1,4 +1,4 @@
-require 'saxon/xdm/node'
+require 'saxon/xdm'
 
 module Saxon
   # Builds XDM objects from XML sources, for use in XSLT or for query and

--- a/lib/saxon/item_type.rb
+++ b/lib/saxon/item_type.rb
@@ -269,8 +269,8 @@ module Saxon
 
     # Convert an XDM Atomic Value to an instance of an appropriate Ruby class, or return the lexical string.
     #
-    # It's assumed that the XdmAtomicValue is of this type, otherwise an error is raised.
-    # @param xdm_atomic_value [Saxon::XdmAtomicValue] The XDM atomic value to be converted.
+    # It's assumed that the XDM::AtomicValue is of this type, otherwise an error is raised.
+    # @param xdm_atomic_value [Saxon::XDM::AtomicValue] The XDM atomic value to be converted.
     def ruby_value(xdm_atomic_value)
       value_to_ruby_convertor.call(xdm_atomic_value)
     end

--- a/lib/saxon/item_type/value_to_ruby.rb
+++ b/lib/saxon/item_type/value_to_ruby.rb
@@ -2,7 +2,7 @@ require 'bigdecimal'
 
 module Saxon
   class ItemType
-    # A collection of lamba-like objects for converting XdmAtomicValues into
+    # A collection of lamba-like objects for converting XDM::AtomicValues into
     # appropriate Ruby values
     module ValueToRuby
       module Patterns

--- a/lib/saxon/loader.rb
+++ b/lib/saxon/loader.rb
@@ -38,7 +38,7 @@ module Saxon
     # @return [true, false] Returns true if Saxon had not been loaded and
     #   is now, and false if Saxon was already loaded
     def self.load!(saxon_home = nil)
-      return false if @saxon_loaded
+      return false if instance_variable_defined?(:@saxon_loaded) && @saxon_loaded
       LOAD_SEMAPHORE.synchronize do
         if Saxon::S9API.const_defined?(:Processor)
           false
@@ -56,7 +56,6 @@ module Saxon
               add_jars_to_classpath!(saxon_home, jars)
             end
           end
-          import_classes_to_namespace!
 
           @saxon_loaded = true
           true
@@ -88,15 +87,6 @@ module Saxon
     def self.add_jars_to_classpath!(saxon_home, jars)
       jars.each do |jar|
         $CLASSPATH << jar.to_s
-      end
-    end
-
-    def self.import_classes_to_namespace!
-      Saxon::S9API.class_eval do
-        include_package 'net.sf.saxon.s9api'
-        java_import 'net.sf.saxon.Configuration'
-        java_import 'net.sf.saxon.lib.FeatureKeys'
-        java_import 'net.sf.saxon.lib.ParseOptions'
       end
     end
   end

--- a/lib/saxon/s9api.rb
+++ b/lib/saxon/s9api.rb
@@ -2,14 +2,32 @@ require 'saxon/loader'
 
 module Saxon
   module S9API
-    def self.const_missing(name)
-      Saxon::Loader.load!
-      begin
-        const_get(name)
-      rescue NameError
-        msg = "uninitialized constant Saxon::S9API::#{name}"
-        e = NameError.new(msg, name)
-        raise e
+    CLASS_IMPORT_SEMAPHORE = Mutex.new
+
+    class << self
+      def const_missing(name)
+        Saxon::Loader.load!
+        begin
+          const_set(name, imported_classes.const_get(name))
+        rescue NameError
+          msg = "uninitialized constant Saxon::S9API::#{name}"
+          e = NameError.new(msg, name)
+          raise e
+        end
+      end
+
+      private
+
+      def imported_classes
+        return @imported_classes if instance_variable_defined?(:@imported_classes)
+        CLASS_IMPORT_SEMAPHORE.synchronize do
+          @imported_classes = Module.new {
+            include_package 'net.sf.saxon.s9api'
+            java_import Java::net.sf.saxon.Configuration
+            java_import Java::net.sf.saxon.lib.FeatureKeys
+            java_import Java::net.sf.saxon.lib.ParseOptions
+          }
+        end
       end
     end
   end

--- a/lib/saxon/xdm.rb
+++ b/lib/saxon/xdm.rb
@@ -26,6 +26,10 @@ module Saxon
       def Array(*args)
         XDM::Array.create(*args)
       end
+
+      def Map(*args)
+        XDM::Map.create(*args)
+      end
     end
   end
 end

--- a/lib/saxon/xdm.rb
+++ b/lib/saxon/xdm.rb
@@ -1,0 +1,22 @@
+require_relative 'xdm/node'
+require_relative 'xdm/atomic_value'
+require_relative 'xdm/value'
+require_relative 'xdm/empty_sequence'
+
+module Saxon
+  module XDM
+    class << self
+      def AtomicValue(*args)
+        XDM::AtomicValue.create(*args)
+      end
+
+      def Value(*args)
+        XDM::Value.create(*args)
+      end
+
+      def EmptySequence()
+        XDM::EmptySequence.create
+      end
+    end
+  end
+end

--- a/lib/saxon/xdm.rb
+++ b/lib/saxon/xdm.rb
@@ -1,7 +1,12 @@
 require_relative 'xdm/node'
 require_relative 'xdm/atomic_value'
+require_relative 'xdm/array'
+require_relative 'xdm/map'
+require_relative 'xdm/function_item'
+require_relative 'xdm/external_object'
 require_relative 'xdm/value'
 require_relative 'xdm/empty_sequence'
+require_relative 'xdm/item'
 
 module Saxon
   module XDM
@@ -16,6 +21,10 @@ module Saxon
 
       def EmptySequence()
         XDM::EmptySequence.create
+      end
+
+      def Array(*args)
+        XDM::Array.create(*args)
       end
     end
   end

--- a/lib/saxon/xdm/array.rb
+++ b/lib/saxon/xdm/array.rb
@@ -1,0 +1,37 @@
+require_relative '../s9api'
+require_relative 'sequence_like'
+
+module Saxon
+  module XDM
+    # Represents an XDM Array
+    class Array
+      def self.create(array)
+        case array
+        when S9API::XdmArray
+          new(array)
+        else
+          new(S9API::XdmArray.new(array.map { |item|
+            XDM.Value(item).to_java
+          }))
+        end
+      end
+
+      include SequenceLike
+      include ItemSequenceLike
+      include Enumerable
+
+      # @api private
+      def initialize(s9_xdm_array)
+        @s9_xdm_array = s9_xdm_array
+      end
+
+      def each(&block)
+        @s9_xdm_array.asList.map { |s9_xdm_value| XDM.Value(s9_xdm_value) }.each(&block)
+      end
+
+      def to_java
+        @s9_xdm_array
+      end
+    end
+  end
+end

--- a/lib/saxon/xdm/array.rb
+++ b/lib/saxon/xdm/array.rb
@@ -53,6 +53,10 @@ module Saxon
         cached_array == other.to_a
       end
 
+      def to_a
+        cached_array
+      end
+
       alias_method :eql?, :==
 
       def hash

--- a/lib/saxon/xdm/array.rb
+++ b/lib/saxon/xdm/array.rb
@@ -20,17 +20,53 @@ module Saxon
       include ItemSequenceLike
       include Enumerable
 
+      attr_reader :s9_xdm_array
+      private :s9_xdm_array
+
       # @api private
       def initialize(s9_xdm_array)
         @s9_xdm_array = s9_xdm_array
       end
 
       def each(&block)
-        @s9_xdm_array.asList.map { |s9_xdm_value| XDM.Value(s9_xdm_value) }.each(&block)
+        cached_array.each(&block)
+      end
+
+      def [](i)
+        cached_array[i]
+      end
+
+      def length
+        s9_xdm_array.arrayLength
+      end
+
+      alias_method :size, :length
+
+      # compares two {XDM::AtomicValue}s using the underlying Saxon and XDM
+      # comparision rules
+      #
+      # @param other [Saxon::XDM::AtomicValue]
+      # @return [Boolean]
+      def ==(other)
+        return false unless other.is_a?(XDM::Array)
+        return false if length != other.length
+        cached_array == other.to_a
+      end
+
+      alias_method :eql?, :==
+
+      def hash
+        @hash ||= cached_array.hash
       end
 
       def to_java
-        @s9_xdm_array
+        s9_xdm_array
+      end
+
+      private
+
+      def cached_array
+        @cached_array ||= s9_xdm_array.asList.map { |s9_xdm_value| XDM.Value(s9_xdm_value) }.freeze
       end
     end
   end

--- a/lib/saxon/xdm/atomic_value.rb
+++ b/lib/saxon/xdm/atomic_value.rb
@@ -1,3 +1,5 @@
+require_relative 'sequence_like'
+require_relative '../s9api'
 require_relative '../qname'
 require_relative '../item_type'
 
@@ -6,6 +8,8 @@ module Saxon
   # An XPath Data Model Node object, representing an XML document, or an element
   # or one of the other node chunks in the XDM.
   class AtomicValue
+    include XDM::SequenceLike
+
     # Error thrown when an attempt to create QName-holding XDM::AtomicValue is
     # made using anything other than a {Saxon::QName} or s9api.QName instance.
     #
@@ -155,6 +159,14 @@ module Saxon
 
     def hash
       @hash ||= s9_xdm_atomic_value.hashCode
+    end
+
+    def sequence_enum
+      [self].to_enum
+    end
+
+    def sequence_size
+      1
     end
   end
 end

--- a/lib/saxon/xdm/atomic_value.rb
+++ b/lib/saxon/xdm/atomic_value.rb
@@ -5,169 +5,169 @@ require_relative '../item_type'
 
 module Saxon
   module XDM
-  # An XPath Data Model Node object, representing an XML document, or an element
-  # or one of the other node chunks in the XDM.
-  class AtomicValue
-    include XDM::SequenceLike
+    # An XPath Data Model Node object, representing an XML document, or an element
+    # or one of the other node chunks in the XDM.
+    class AtomicValue
+      include XDM::SequenceLike
+      include XDM::ItemSequenceLike
 
-    # Error thrown when an attempt to create QName-holding XDM::AtomicValue is
-    # made using anything other than a {Saxon::QName} or s9api.QName instance.
-    #
-    # QNames are dependent on the namespace URI, which isn't present in the
-    # lexical string you normally see (e.g. <tt>prefix:name</tt>). Prefixes are
-    # only bound to a URI in the context of a particular document, so creating
-    # them imlpicitly through the XDM::AtomicValue creation process doesn't really
-    # work. They need to be created explicitly and then handed in to be wrapped.
-    class CannotCreateQNameFromString < StandardError
+      # Error thrown when an attempt to create QName-holding XDM::AtomicValue is
+      # made using anything other than a {Saxon::QName} or s9api.QName instance.
+      #
+      # QNames are dependent on the namespace URI, which isn't present in the
+      # lexical string you normally see (e.g. <tt>prefix:name</tt>). Prefixes are
+      # only bound to a URI in the context of a particular document, so creating
+      # them imlpicitly through the XDM::AtomicValue creation process doesn't really
+      # work. They need to be created explicitly and then handed in to be wrapped.
+      class CannotCreateQNameFromString < StandardError
+        def to_s
+          "QName XDM::AtomicValues must be created using an instance of Saxon::QName, not a string like 'prefix:name': Prefix URI binding is undefined at this point"
+        end
+      end
+
+      # xs:NOTATION is another QName-holding XDM type. Unlike xs:QName, there
+      # isn't a way to create these outside of parsing an XML document within
+      # Saxon, so attempting to do so raises this error.
+      class NotationCannotBeDirectlyCreated < StandardError
+        def to_s
+          "xs:NOTATION XDM::AtomicValues cannot be directly created outside of XML parsing."
+        end
+      end
+
+      XS_QNAME = ItemType.get_type('xs:QName')
+      XS_NOTATION = ItemType.get_type('xs:NOTATION')
+
+      class << self
+        # Convert a single Ruby value into an XDM::AtomicValue
+        #
+        # If no explicit {ItemType} is passed, the correct type is guessed based
+        # on the class of the value. (e.g. <tt>xs:date</tt> for {Date}.)
+        #
+        # Values are converted based on Ruby idioms and operations, so an explicit
+        # {ItemType} of <tt>xs:boolean</tt> will use truthyness to evaluate the
+        # value. This means that the Ruby string <tt>'false'</tt> will produce an
+        # <tt>xs:boolean</tt> whose value is <tt>true</tt>, because all strings
+        # are truthy. If you need to pass lexical strings unchanged, use
+        # {XDM::AtomicValue.from_lexical_string}.
+        #
+        # @param value [Object] the value to convert
+        #
+        # @param item_type [Saxon::ItemType, String] the value's type, as either
+        #   an {ItemType} or a name (<tt>xs:date</tt>)
+        #
+        # @return [Saxon::XDM::AtomicValue]
+        def create(value, item_type = nil)
+          case value
+          when Saxon::S9API::XdmAtomicValue
+            new(value)
+          when XDM::AtomicValue
+            value
+          else
+            return create_implying_item_type(value) if item_type.nil?
+
+            item_type = ItemType.get_type(item_type)
+
+            return new(Saxon::S9API::XdmAtomicValue.new(value.to_java)) if item_type == XS_QNAME && value_is_qname?(value)
+            raise NotationCannotBeDirectlyCreated if item_type == XS_NOTATION
+
+            value_lexical_string = item_type.lexical_string(value)
+            new(new_s9_xdm_atomic_value(value_lexical_string, item_type))
+          end
+        end
+
+        # convert a lexical string representation of an XDM Atomic Value into an
+        # XDM::AtomicValue.
+        #
+        # Note that this skips all conversion and checking of the string before
+        # handing it off to Saxon.
+        #
+        # @param value [String] the lexical string representation of the value
+        # @param item_type [Saxon::ItemType, String] the value's type, as either
+        #   an {ItemType} or a name (<tt>xs:date</tt>)
+        # @return [Saxon::XDM::AtomicValue]
+        def from_lexical_string(value, item_type)
+          item_type = ItemType.get_type(item_type)
+          raise CannotCreateQNameFromString if item_type == XS_QNAME
+          new(new_s9_xdm_atomic_value(value.to_s, item_type))
+        end
+
+        private
+
+        def new_s9_xdm_atomic_value(value, item_type)
+          Saxon::S9API::XdmAtomicValue.new(value.to_java, item_type.to_java)
+        end
+
+        def create_implying_item_type(value)
+          return new(Saxon::S9API::XdmAtomicValue.new(value.to_java)) if value_is_qname?(value)
+
+          item_type = ItemType.get_type(value.class)
+
+          new(new_s9_xdm_atomic_value(item_type.lexical_string(value), item_type))
+        end
+
+        def value_is_qname?(value)
+          QName === value || S9API::QName === value
+        end
+      end
+
+      attr_reader :s9_xdm_atomic_value
+      private :s9_xdm_atomic_value
+
+      # @api private
+      def initialize(s9_xdm_atomic_value)
+        @s9_xdm_atomic_value = s9_xdm_atomic_value
+      end
+
+      # Return a {QName} representing the type of the value
+      #
+      # @return [Saxon::QName] the {QName} of the value's type
+      def type_name
+        @type_name ||= Saxon::QName.new(s9_xdm_atomic_value.getTypeName)
+      end
+
+      # @return [Saxon::S9API::XdmAtomicValue] The underlying Saxon Java XDM
+      # atomic value object.
+      def to_java
+        s9_xdm_atomic_value
+      end
+
+      # Return the value as a String. Like calling XPath's <tt>string()</tt>
+      # function.
+      #
+      # @return [String] The string representation of the value
       def to_s
-        "QName XDM::AtomicValues must be created using an instance of Saxon::QName, not a string like 'prefix:name': Prefix URI binding is undefined at this point"
-      end
-    end
-
-    # xs:NOTATION is another QName-holding XDM type. Unlike xs:QName, there
-    # isn't a way to create these outside of parsing an XML document within
-    # Saxon, so attempting to do so raises this error.
-    class NotationCannotBeDirectlyCreated < StandardError
-      def to_s
-        "xs:NOTATION XDM::AtomicValues cannot be directly created outside of XML parsing."
-      end
-    end
-
-    XS_QNAME = ItemType.get_type('xs:QName')
-    XS_NOTATION = ItemType.get_type('xs:NOTATION')
-
-    class << self
-      # Convert a single Ruby value into an XDM::AtomicValue
-      #
-      # If no explicit {ItemType} is passed, the correct type is guessed based
-      # on the class of the value. (e.g. <tt>xs:date</tt> for {Date}.)
-      #
-      # Values are converted based on Ruby idioms and operations, so an explicit
-      # {ItemType} of <tt>xs:boolean</tt> will use truthyness to evaluate the
-      # value. This means that the Ruby string <tt>'false'</tt> will produce an
-      # <tt>xs:boolean</tt> whose value is <tt>true</tt>, because all strings
-      # are truthy. If you need to pass lexical strings unchanged, use
-      # {XDM::AtomicValue.from_lexical_string}.
-      #
-      # @param value [Object] the value to convert
-      #
-      # @param item_type [Saxon::ItemType, String] the value's type, as either
-      #   an {ItemType} or a name (<tt>xs:date</tt>)
-      #
-      # @return [Saxon::XDM::AtomicValue]
-      def create(value, item_type = nil)
-        return create_implying_item_type(value) if item_type.nil?
-
-        item_type = ItemType.get_type(item_type)
-
-        return new(Saxon::S9API::XdmAtomicValue.new(value.to_java)) if item_type == XS_QNAME && value_is_qname?(value)
-        raise NotationCannotBeDirectlyCreated if item_type == XS_NOTATION
-
-        value_lexical_string = item_type.lexical_string(value)
-        new(new_s9_xdm_atomic_value(value_lexical_string, item_type))
+        s9_xdm_atomic_value.toString
       end
 
-      # convert a lexical string representation of an XDM Atomic Value into an
-      # XDM::AtomicValue.
+      # @return [Saxon::ItemType] The ItemType of the value
+      def item_type
+        @item_type ||= Saxon::ItemType.get_type(Saxon::QName.resolve(s9_xdm_atomic_value.getTypeName))
+      end
+
+      # Return the value as an instance of the Ruby class that best represents the
+      # type of the value. Types with no sensible equivalent are returned as their
+      # lexical string form
       #
-      # Note that this skips all conversion and checking of the string before
-      # handing it off to Saxon.
+      # @return [Object] A Ruby object representation of the value
+      def to_ruby
+        @ruby_value ||= item_type.ruby_value(self).freeze
+      end
+
+      # compares two {XDM::AtomicValue}s using the underlying Saxon and XDM
+      # comparision rules
       #
-      # @param value [String] the lexical string representation of the value
-      # @param item_type [Saxon::ItemType, String] the value's type, as either
-      #   an {ItemType} or a name (<tt>xs:date</tt>)
-      # @return [Saxon::XDM::AtomicValue]
-      def from_lexical_string(value, item_type)
-        item_type = ItemType.get_type(item_type)
-        raise CannotCreateQNameFromString if item_type == XS_QNAME
-        new(new_s9_xdm_atomic_value(value.to_s, item_type))
+      # @param other [Saxon::XDM::AtomicValue]
+      # @return [Boolean]
+      def ==(other)
+        return false unless other.is_a?(XDM::AtomicValue)
+        s9_xdm_atomic_value.equals(other.to_java)
       end
 
-      private
+      alias_method :eql?, :==
 
-      def new_s9_xdm_atomic_value(value, item_type)
-        Saxon::S9API::XdmAtomicValue.new(value.to_java, item_type.to_java)
+      def hash
+        @hash ||= s9_xdm_atomic_value.hashCode
       end
-
-      def create_implying_item_type(value)
-        return new(Saxon::S9API::XdmAtomicValue.new(value.to_java)) if value_is_qname?(value)
-
-        item_type = ItemType.get_type(value.class)
-
-        new(new_s9_xdm_atomic_value(item_type.lexical_string(value), item_type))
-      end
-
-      def value_is_qname?(value)
-        QName === value || S9API::QName === value
-      end
-    end
-
-    attr_reader :s9_xdm_atomic_value
-    private :s9_xdm_atomic_value
-
-    # @api private
-    def initialize(s9_xdm_atomic_value)
-      @s9_xdm_atomic_value = s9_xdm_atomic_value
-    end
-
-    # Return a {QName} representing the type of the value
-    #
-    # @return [Saxon::QName] the {QName} of the value's type
-    def type_name
-      @type_name ||= Saxon::QName.new(s9_xdm_atomic_value.getTypeName)
-    end
-
-    # @return [Saxon::S9API::XdmAtomicValue] The underlying Saxon Java XDM
-    # atomic value object.
-    def to_java
-      s9_xdm_atomic_value
-    end
-
-    # Return the value as a String. Like calling XPath's <tt>string()</tt>
-    # function.
-    #
-    # @return [String] The string representation of the value
-    def to_s
-      s9_xdm_atomic_value.toString
-    end
-
-    # @return [Saxon::ItemType] The ItemType of the value
-    def item_type
-      @item_type ||= Saxon::ItemType.get_type(Saxon::QName.resolve(s9_xdm_atomic_value.getTypeName))
-    end
-
-    # Return the value as an instance of the Ruby class that best represents the
-    # type of the value. Types with no sensible equivalent are returned as their
-    # lexical string form
-    #
-    # @return [Object] A Ruby object representation of the value
-    def to_ruby
-      @ruby_value ||= item_type.ruby_value(self).freeze
-    end
-
-    # compares two {XDM::AtomicValue}s using the underlying Saxon and XDM
-    # comparision rules
-    #
-    # @param other [Saxon::XDM::AtomicValue]
-    # @return [Boolean]
-    def ==(other)
-      return false unless other.is_a?(XDM::AtomicValue)
-      s9_xdm_atomic_value.equals(other.to_java)
-    end
-
-    alias_method :eql?, :==
-
-    def hash
-      @hash ||= s9_xdm_atomic_value.hashCode
-    end
-
-    def sequence_enum
-      [self].to_enum
-    end
-
-    def sequence_size
-      1
     end
   end
-end
 end

--- a/lib/saxon/xdm/atomic_value.rb
+++ b/lib/saxon/xdm/atomic_value.rb
@@ -1,21 +1,22 @@
-require_relative 'qname'
-require_relative 'item_type'
+require_relative '../qname'
+require_relative '../item_type'
 
 module Saxon
+  module XDM
   # An XPath Data Model Node object, representing an XML document, or an element
   # or one of the other node chunks in the XDM.
-  class XdmAtomicValue
-    # Error thrown when an attempt to create QName-holding XdmAtomicValue is
+  class AtomicValue
+    # Error thrown when an attempt to create QName-holding XDM::AtomicValue is
     # made using anything other than a {Saxon::QName} or s9api.QName instance.
     #
     # QNames are dependent on the namespace URI, which isn't present in the
     # lexical string you normally see (e.g. <tt>prefix:name</tt>). Prefixes are
     # only bound to a URI in the context of a particular document, so creating
-    # them imlpicitly through the XdmAtomicValue creation process doesn't really
+    # them imlpicitly through the XDM::AtomicValue creation process doesn't really
     # work. They need to be created explicitly and then handed in to be wrapped.
     class CannotCreateQNameFromString < StandardError
       def to_s
-        "QName XdmAtomicValues must be created using an instance of Saxon::QName, not a string like 'prefix:name': Prefix URI binding is undefined at this point"
+        "QName XDM::AtomicValues must be created using an instance of Saxon::QName, not a string like 'prefix:name': Prefix URI binding is undefined at this point"
       end
     end
 
@@ -24,7 +25,7 @@ module Saxon
     # Saxon, so attempting to do so raises this error.
     class NotationCannotBeDirectlyCreated < StandardError
       def to_s
-        "xs:NOTATION XdmAtomicValues cannot be directly created outside of XML parsing."
+        "xs:NOTATION XDM::AtomicValues cannot be directly created outside of XML parsing."
       end
     end
 
@@ -32,7 +33,7 @@ module Saxon
     XS_NOTATION = ItemType.get_type('xs:NOTATION')
 
     class << self
-      # Convert a single Ruby value into an XdmAtomicValue
+      # Convert a single Ruby value into an XDM::AtomicValue
       #
       # If no explicit {ItemType} is passed, the correct type is guessed based
       # on the class of the value. (e.g. <tt>xs:date</tt> for {Date}.)
@@ -42,14 +43,14 @@ module Saxon
       # value. This means that the Ruby string <tt>'false'</tt> will produce an
       # <tt>xs:boolean</tt> whose value is <tt>true</tt>, because all strings
       # are truthy. If you need to pass lexical strings unchanged, use
-      # {XdmAtomicValue.from_lexical_string}.
+      # {XDM::AtomicValue.from_lexical_string}.
       #
       # @param value [Object] the value to convert
       #
       # @param item_type [Saxon::ItemType, String] the value's type, as either
       #   an {ItemType} or a name (<tt>xs:date</tt>)
       #
-      # @return [Saxon::XdmAtomicValue]
+      # @return [Saxon::XDM::AtomicValue]
       def create(value, item_type = nil)
         return create_implying_item_type(value) if item_type.nil?
 
@@ -63,7 +64,7 @@ module Saxon
       end
 
       # convert a lexical string representation of an XDM Atomic Value into an
-      # XdmAtomicValue.
+      # XDM::AtomicValue.
       #
       # Note that this skips all conversion and checking of the string before
       # handing it off to Saxon.
@@ -71,7 +72,7 @@ module Saxon
       # @param value [String] the lexical string representation of the value
       # @param item_type [Saxon::ItemType, String] the value's type, as either
       #   an {ItemType} or a name (<tt>xs:date</tt>)
-      # @return [Saxon::XdmAtomicValue]
+      # @return [Saxon::XDM::AtomicValue]
       def from_lexical_string(value, item_type)
         item_type = ItemType.get_type(item_type)
         raise CannotCreateQNameFromString if item_type == XS_QNAME
@@ -140,13 +141,13 @@ module Saxon
       @ruby_value ||= item_type.ruby_value(self).freeze
     end
 
-    # compares two {XdmAtomicValue}s using the underlying Saxon and XDM
+    # compares two {XDM::AtomicValue}s using the underlying Saxon and XDM
     # comparision rules
     #
-    # @param other [Saxon::XdmAtomicValue]
+    # @param other [Saxon::XDM::AtomicValue]
     # @return [Boolean]
     def ==(other)
-      return false unless other.is_a?(XdmAtomicValue)
+      return false unless other.is_a?(XDM::AtomicValue)
       s9_xdm_atomic_value.equals(other.to_java)
     end
 
@@ -156,4 +157,5 @@ module Saxon
       @hash ||= s9_xdm_atomic_value.hashCode
     end
   end
+end
 end

--- a/lib/saxon/xdm/empty_sequence.rb
+++ b/lib/saxon/xdm/empty_sequence.rb
@@ -1,0 +1,37 @@
+require_relative '../s9api'
+require_relative 'sequence_like'
+
+module Saxon
+  module XDM
+    # Represents the empty sequence in XDM
+    class EmptySequence
+      def self.create
+        @instance ||= new
+      end
+
+      include SequenceLike
+
+      def sequence_enum
+        [].to_enum
+      end
+
+      def sequence_size
+        0
+      end
+
+      def ==(other)
+        other.class == self.class
+      end
+
+      alias_method :eql?, :==
+
+      def hash
+        [].hash
+      end
+
+      def to_java
+        @s9_xdm_empty_sequence ||= Saxon::S9API::XdmEmptySequence.getInstance
+      end
+    end
+  end
+end

--- a/lib/saxon/xdm/external_object.rb
+++ b/lib/saxon/xdm/external_object.rb
@@ -1,0 +1,21 @@
+require_relative '../s9api'
+require_relative 'sequence_like'
+
+module Saxon
+  module XDM
+    # Represents a Saxon XDM ExternalObject
+    class ExternalObject
+      include SequenceLike
+      include ItemSequenceLike
+
+      # @api private
+      def initialize(s9_xdm_external_object)
+        @s9_xdm_external_object = s9_xdm_external_object
+      end
+
+      def to_java
+        @s9_xdm_external_object
+      end
+    end
+  end
+end

--- a/lib/saxon/xdm/function_item.rb
+++ b/lib/saxon/xdm/function_item.rb
@@ -1,0 +1,21 @@
+require_relative '../s9api'
+require_relative 'sequence_like'
+
+module Saxon
+  module XDM
+    # Represents an XDM Function Item
+    class FunctionItem
+      include SequenceLike
+      include ItemSequenceLike
+
+      # @api private
+      def initialize(s9_xdm_function_item)
+        @s9_xdm_function_item = s9_xdm_function_item
+      end
+
+      def to_java
+        @s9_xdm_function_item
+      end
+    end
+  end
+end

--- a/lib/saxon/xdm/item.rb
+++ b/lib/saxon/xdm/item.rb
@@ -16,8 +16,16 @@ module Saxon
         Map.new(item)
       when Saxon::S9API::XdmValue
         Value.new(item)
+      when ::Array
+        Array.create(item)
+      when ::Hash
+        Map.create(item)
       else
-        AtomicValue.create(item)
+        if item.respond_to?(:each)
+          Array.create(item)
+        else
+          AtomicValue.create(item)
+        end
       end
     end
   end

--- a/lib/saxon/xdm/item.rb
+++ b/lib/saxon/xdm/item.rb
@@ -1,0 +1,24 @@
+module Saxon
+  module XDM
+    def self.Item(item)
+      case item
+      when Value, AtomicValue, Node, Array, Map, ExternalObject
+        item
+      when Saxon::S9API::XdmNode
+        Node.new(item)
+      when Saxon::S9API::XdmAtomicValue
+        AtomicValue.new(item)
+      when Saxon::S9API::XdmExternalObject
+        ExternalObject.new(item)
+      when Saxon::S9API::XdmArray
+        Array.new(item)
+      when Saxon::S9API::XdmMap
+        Map.new(item)
+      when Saxon::S9API::XdmValue
+        Value.new(item)
+      else
+        AtomicValue.create(item)
+      end
+    end
+  end
+end

--- a/lib/saxon/xdm/map.rb
+++ b/lib/saxon/xdm/map.rb
@@ -22,6 +22,9 @@ module Saxon
       include ItemSequenceLike
       include Enumerable
 
+      attr_reader :s9_xdm_map
+      private :s9_xdm_map
+
       # @api private
       def initialize(s9_xdm_map)
         @s9_xdm_map = s9_xdm_map
@@ -33,11 +36,15 @@ module Saxon
       end
 
       def [](key)
-        XDM.Value(@s9_xdm_map.get(XDM.AtomicValue(key).to_java))
+        cached_hash[XDM.AtomicValue(key)]
+      end
+
+      def fetch(key, *args, &block)
+        cached_hash.fetch(XDM.AtomicValue(key), *args, &block)
       end
 
       def each(&block)
-        @s9_xdm_map.entrySet.map { |entry| [XDM.AtomicValue(entry.getKey), XDM.Value(entry.getValue)] }.each(&block)
+        cached_hash.each(&block)
       end
 
       def select(&block)
@@ -54,6 +61,16 @@ module Saxon
 
       def to_java
         @s9_xdm_map
+      end
+
+      def to_h
+        cached_hash
+      end
+
+      private
+
+      def cached_hash
+        @cached_hash ||= s9_xdm_map.entrySet.map { |entry| [XDM.AtomicValue(entry.getKey), XDM.Value(entry.getValue)] }.to_h.freeze
       end
     end
   end

--- a/lib/saxon/xdm/map.rb
+++ b/lib/saxon/xdm/map.rb
@@ -1,0 +1,60 @@
+require_relative '../s9api'
+require_relative 'sequence_like'
+
+module Saxon
+  module XDM
+    # Represents an XDM Map
+    class Map
+      def self.create(hash)
+        case hash
+        when Saxon::S9API::XdmMap
+          new(hash)
+        else
+          new(S9API::XdmMap.new(Hash[
+            hash.map { |key, value|
+              [XDM.AtomicValue(key).to_java, XDM.Value(value).to_java]
+            }
+          ]))
+        end
+      end
+
+      include SequenceLike
+      include ItemSequenceLike
+      include Enumerable
+
+      # @api private
+      def initialize(s9_xdm_map)
+        @s9_xdm_map = s9_xdm_map
+      end
+
+      def ==(other)
+        return false unless other.is_a?(self.class)
+        to_h == other.to_h
+      end
+
+      def [](key)
+        XDM.Value(@s9_xdm_map.get(XDM.AtomicValue(key).to_java))
+      end
+
+      def each(&block)
+        @s9_xdm_map.entrySet.map { |entry| [XDM.AtomicValue(entry.getKey), XDM.Value(entry.getValue)] }.each(&block)
+      end
+
+      def select(&block)
+        self.class.create(each.select(&block).to_h)
+      end
+
+      def reject(&block)
+        self.class.create(each.reject(&block).to_h)
+      end
+
+      def merge(other)
+        self.class.create(to_h.merge(other.to_h))
+      end
+
+      def to_java
+        @s9_xdm_map
+      end
+    end
+  end
+end

--- a/lib/saxon/xdm/node.rb
+++ b/lib/saxon/xdm/node.rb
@@ -4,75 +4,68 @@ require_relative 'sequence_like'
 
 module Saxon
   module XDM
-  # An XPath Data Model Node object, representing an XML document, or an element or one of the other node chunks in the XDM.
-  class Node
-    include XDM::SequenceLike
-    include Enumerable
+    # An XPath Data Model Node object, representing an XML document, or an element or one of the other node chunks in the XDM.
+    class Node
+      include XDM::SequenceLike
+      include XDM::ItemSequenceLike
+      include Enumerable
 
-    attr_reader :s9_xdm_node
-    private :s9_xdm_node
+      attr_reader :s9_xdm_node
+      private :s9_xdm_node
 
-    # @api private
-    def initialize(s9_xdm_node)
-      @s9_xdm_node = s9_xdm_node
-    end
+      # @api private
+      def initialize(s9_xdm_node)
+        @s9_xdm_node = s9_xdm_node
+      end
 
-    # @return [Saxon::S9API::XdmNode] The underlying Saxon Java XDM node object.
-    def to_java
-      @s9_xdm_node
-    end
+      # @return [Saxon::S9API::XdmNode] The underlying Saxon Java XDM node object.
+      def to_java
+        @s9_xdm_node
+      end
 
-    def node_name
-      return @node_name if instance_variable_defined?(:@node_name)
-      node_name = s9_xdm_node.getNodeName
-      @node_name = node_name.nil? ? nil : Saxon::QName.new(node_name)
-    end
+      def node_name
+        return @node_name if instance_variable_defined?(:@node_name)
+        node_name = s9_xdm_node.getNodeName
+        @node_name = node_name.nil? ? nil : Saxon::QName.new(node_name)
+      end
 
-    def node_kind
-      @node_kind ||= case s9_xdm_node.nodeKind
-      when Saxon::S9API::XdmNodeKind::ELEMENT
-        :element
-      when Saxon::S9API::XdmNodeKind::TEXT
-        :text
-      when Saxon::S9API::XdmNodeKind::ATTRIBUTE
-        :attribute
-      when Saxon::S9API::XdmNodeKind::NAMESPACE
-        :namespace
-      when Saxon::S9API::XdmNodeKind::COMMENT
-        :comment
-      when Saxon::S9API::XdmNodeKind::PROCESSING_INSTRUCTION
-        :processing_instruction
-      when Saxon::S9API::XdmNodeKind::DOCUMENT
-        :document
+      def node_kind
+        @node_kind ||= case s9_xdm_node.nodeKind
+        when Saxon::S9API::XdmNodeKind::ELEMENT
+          :element
+        when Saxon::S9API::XdmNodeKind::TEXT
+          :text
+        when Saxon::S9API::XdmNodeKind::ATTRIBUTE
+          :attribute
+        when Saxon::S9API::XdmNodeKind::NAMESPACE
+          :namespace
+        when Saxon::S9API::XdmNodeKind::COMMENT
+          :comment
+        when Saxon::S9API::XdmNodeKind::PROCESSING_INSTRUCTION
+          :processing_instruction
+        when Saxon::S9API::XdmNodeKind::DOCUMENT
+          :document
+        end
+      end
+
+      def ==(other)
+        return false unless other.is_a?(XDM::Node)
+        s9_xdm_node.equals(other.to_java)
+      end
+
+      alias_method :eql?, :==
+
+      def hash
+        @hash ||= s9_xdm_node.hashCode
+      end
+
+      def each(&block)
+        axis_iterator(:child).each(&block)
+      end
+
+      def axis_iterator(axis)
+        AxisIterator.new(self, axis)
       end
     end
-
-    def ==(other)
-      return false unless other.is_a?(XDM::Node)
-      s9_xdm_node.equals(other.to_java)
-    end
-
-    alias_method :eql?, :==
-
-    def hash
-      @hash ||= s9_xdm_node.hashCode
-    end
-
-    def each(&block)
-      axis_iterator(:child).each(&block)
-    end
-
-    def axis_iterator(axis)
-      AxisIterator.new(self, axis)
-    end
-
-    def sequence_enum
-      [self].to_enum
-    end
-
-    def sequence_size
-      1
-    end
   end
-end
 end

--- a/lib/saxon/xdm/node.rb
+++ b/lib/saxon/xdm/node.rb
@@ -1,9 +1,12 @@
 require_relative '../axis_iterator'
+require_relative '../s9api'
+require_relative 'sequence_like'
 
 module Saxon
   module XDM
   # An XPath Data Model Node object, representing an XML document, or an element or one of the other node chunks in the XDM.
   class Node
+    include XDM::SequenceLike
     include Enumerable
 
     attr_reader :s9_xdm_node
@@ -61,6 +64,14 @@ module Saxon
 
     def axis_iterator(axis)
       AxisIterator.new(self, axis)
+    end
+
+    def sequence_enum
+      [self].to_enum
+    end
+
+    def sequence_size
+      1
     end
   end
 end

--- a/lib/saxon/xdm/node.rb
+++ b/lib/saxon/xdm/node.rb
@@ -1,8 +1,9 @@
-require_relative 'axis_iterator'
+require_relative '../axis_iterator'
 
 module Saxon
+  module XDM
   # An XPath Data Model Node object, representing an XML document, or an element or one of the other node chunks in the XDM.
-  class XdmNode
+  class Node
     include Enumerable
 
     attr_reader :s9_xdm_node
@@ -44,7 +45,7 @@ module Saxon
     end
 
     def ==(other)
-      return false unless other.is_a?(XdmNode)
+      return false unless other.is_a?(XDM::Node)
       s9_xdm_node.equals(other.to_java)
     end
 
@@ -62,4 +63,5 @@ module Saxon
       AxisIterator.new(self, axis)
     end
   end
+end
 end

--- a/lib/saxon/xdm/sequence_like.rb
+++ b/lib/saxon/xdm/sequence_like.rb
@@ -1,0 +1,20 @@
+module Saxon
+  module XDM
+    module SequenceLike
+      def sequence_enum
+        raise NotImplementedError
+      end
+
+      def sequence_size
+        raise NotImplementedError
+      end
+
+      def append(other)
+        XDM::Value.create([self, other])
+      end
+
+      alias_method :<<, :append
+      alias_method :+, :append
+    end
+  end
+end

--- a/lib/saxon/xdm/sequence_like.rb
+++ b/lib/saxon/xdm/sequence_like.rb
@@ -16,5 +16,15 @@ module Saxon
       alias_method :<<, :append
       alias_method :+, :append
     end
+
+    module ItemSequenceLike
+      def sequence_enum
+        [self].to_enum
+      end
+
+      def sequence_size
+        1
+      end
+    end
   end
 end

--- a/lib/saxon/xdm/value.rb
+++ b/lib/saxon/xdm/value.rb
@@ -1,9 +1,10 @@
-require_relative 'xdm_node'
-require_relative 'xdm_atomic_value'
+require_relative 'node'
+require_relative 'atomic_value'
 
 module Saxon
+  module XDM
   # An XPath Data Model Value object, representing a Sequence.
-  class XdmValue
+  class Value
     include Enumerable
 
     def self.wrap_s9_xdm_value(s9_xdm_value)
@@ -18,21 +19,21 @@ module Saxon
 
     def self.wrap_s9_xdm_item(s9_xdm_item)
       if s9_xdm_item.isAtomicValue
-        XdmAtomicValue.new(s9_xdm_item)
+        XDM::AtomicValue.new(s9_xdm_item)
       else
         case s9_xdm_item
         when Saxon::S9API::XdmNode
-          XdmNode.new(s9_xdm_item)
+          XDM::Node.new(s9_xdm_item)
         else
-          XdmUnhandledItem.new(s9_xdm_item)
+          XDM::UnhandledItem.new(s9_xdm_item)
         end
       end
     end
 
-    # Create a new XdmValue sequence containing the items passed in as a Ruby enumerable.
+    # Create a new XDM::Value sequence containing the items passed in as a Ruby enumerable.
     #
     # @param items [Enumerable] A list of XDM Item members
-    # @return [Saxon::XdmValue] The XDM value
+    # @return [Saxon::XDM::Value] The XDM value
     def self.create(items)
       new(Saxon::S9API::XdmValue.makeSequence(items.map(&:to_java)))
     end
@@ -57,7 +58,7 @@ module Saxon
     #
     # @overload
     #   @yield [item] The current XDM Item
-    #   @yieldparam item [Saxon::XdmAtomicValue, Saxon::XdmNode] the item.
+    #   @yieldparam item [Saxon::XDM::AtomicValue, Saxon::XDM::Node] the item.
     def each(&block)
       to_enum.each(&block)
     end
@@ -67,14 +68,14 @@ module Saxon
       @s9_xdm_value
     end
 
-    # Compare this XdmValue with another. Currently this requires iterating
+    # Compare this XDM::Value with another. Currently this requires iterating
     # across the sequence, and the other sequence and comparing each member
     # with the corresponding member in the other sequence.
     #
-    # @param other [Saxon::XdmValue] The XdmValue to be compare against
-    # @return [Boolean] whether the two XdmValues are equal
+    # @param other [Saxon::XDM::Value] The XDM::Value to be compare against
+    # @return [Boolean] whether the two XDM::Values are equal
     def ==(other)
-      return false unless other.is_a?(XdmValue)
+      return false unless other.is_a?(XDM::Value)
       return false unless other.size == size
       not_okay = to_enum.zip(other.to_enum).find { |mine, theirs|
         mine != theirs
@@ -84,7 +85,7 @@ module Saxon
 
     alias_method :eql?, :==
 
-    # The hash code for the XdmValue
+    # The hash code for the XDM::Value
     # @return [Fixnum] The hash code
     def hash
       @hash ||= to_a.hash
@@ -102,7 +103,7 @@ module Saxon
   end
 
   # Placeholder class for Saxon Items that we haven't gotten to yet
-  class XdmUnhandledItem
+  class XDM::UnhandledItem
     def initialize(s9_xdm_item)
       @s9_xdm_item = s9_xdm_item
     end
@@ -111,4 +112,5 @@ module Saxon
       @s9_xdm_item
     end
   end
+end
 end

--- a/lib/saxon/xdm/value.rb
+++ b/lib/saxon/xdm/value.rb
@@ -3,158 +3,143 @@ require_relative 'sequence_like'
 
 module Saxon
   module XDM
-    def self.Item(item)
-      case item
-      when Value, AtomicValue, Node
-        item
-      when Saxon::S9API::XdmNode
-        Node.new(item)
-      when Saxon::S9API::XdmAtomicValue
-        AtomicValue.new(item)
-      when Saxon::S9API::XdmValue
-        new(item)
-      else
-        AtomicValue.create(item)
-      end
-    end
+    # An XPath Data Model Value object, representing a Sequence.
+    class Value
+      include XDM::SequenceLike
+      include Enumerable
 
-  # An XPath Data Model Value object, representing a Sequence.
-  class Value
-    include XDM::SequenceLike
-    include Enumerable
-
-    class << self
-      # Create a new XDM::Value sequence containing the items passed in as a Ruby enumerable.
-      #
-      # @param items [Enumerable] A list of members
-      # @return [Saxon::XDM::Value] The XDM value
-      def create(*items)
-        items = items.flatten
-        case items.size
-        when 0
-          XDM.EmptySequence()
-        when 1
-          if existing_value = is_xdm_value?(items.first)
-            return existing_value
+      class << self
+        # Create a new XDM::Value sequence containing the items passed in as a Ruby enumerable.
+        #
+        # @param items [Enumerable] A list of members
+        # @return [Saxon::XDM::Value] The XDM value
+        def create(*items)
+          items = items.flatten
+          case items.size
+          when 0
+            XDM.EmptySequence()
+          when 1
+            if existing_value = maybe_xdm_value(items.first)
+              return existing_value
+            end
+            XDM.Item(items.first)
+          else
+            new(Saxon::S9API::XdmValue.new(wrap_items(items)))
           end
-          XDM.Item(items.first)
-        else
-          new(Saxon::S9API::XdmValue.new(wrap_items(items)))
         end
-      end
 
-      private
+        private
 
-      def is_xdm_value?(item)
-        return item if item.is_a?(self)
-        return new(item) if item.instance_of?(Saxon::S9API::XdmValue)
-        false
-      end
+        def maybe_xdm_value(item)
+          return item if item.is_a?(self)
+          return new(item) if item.instance_of?(Saxon::S9API::XdmValue)
+          false
+        end
 
-      def wrap_items(items)
-        result = []
-        items.map { |item|
-          wrap_item(item, result)
-        }
-        result
-      end
+        def wrap_items(items)
+          result = []
+          items.map { |item|
+            wrap_item(item, result)
+          }
+          result
+        end
 
-      def wrap_item(item, result)
-        if item.respond_to?(:sequence_enum)
-          item.sequence_enum.each do |item|
-            result << item.to_java
-          end
-        elsif item.respond_to?(:each)
-          item.each do |item|
+        def wrap_item(item, result)
+          if item.respond_to?(:sequence_enum)
+            item.sequence_enum.each do |item|
+              result << item.to_java
+            end
+          elsif item.respond_to?(:each)
+            item.each do |item|
+              result << XDM.Item(item).to_java
+            end
+          else
             result << XDM.Item(item).to_java
           end
-        else
-          result << XDM.Item(item).to_java
         end
+      end
+
+      attr_reader :s9_xdm_value
+      private :s9_xdm_value
+
+      # @api private
+      def initialize(s9_xdm_value)
+        @s9_xdm_value = s9_xdm_value
+      end
+
+      # @return [Fixnum] The size of the sequence
+      def size
+        s9_xdm_value.size
+      end
+
+      # Calls the given block once for each Item in the sequence, passing that
+      # item as a parameter. Returns the value itself.
+      #
+      # If no block is given, an Enumerator is returned.
+      #
+      # @overload
+      #   @yield [item] The current XDM Item
+      #   @yieldparam item [Saxon::XDM::AtomicValue, Saxon::XDM::Node] the item.
+      def each(&block)
+        to_enum.each(&block)
+      end
+
+      # @return [Saxon::S9API::XdmValue] The underlying Saxon Java XDM valuee object.
+      def to_java
+        @s9_xdm_value
+      end
+
+      # Compare this XDM::Value with another. Currently this requires iterating
+      # across the sequence, and the other sequence and comparing each member
+      # with the corresponding member in the other sequence.
+      #
+      # @param other [Saxon::XDM::Value] The XDM::Value to be compare against
+      # @return [Boolean] whether the two XDM::Values are equal
+      def ==(other)
+        return false unless other.is_a?(XDM::Value)
+        return false unless other.size == size
+        not_okay = to_enum.zip(other.to_enum).find { |mine, theirs|
+          mine != theirs
+        }
+        not_okay.nil? || !not_okay
+      end
+
+      alias_method :eql?, :==
+
+      # The hash code for the XDM::Value
+      # @return [Fixnum] The hash code
+      def hash
+        @hash ||= to_a.hash
+      end
+
+      # Returns a lazy Enumerator over the sequence
+      # @return [Enumerator::Lazy] the enumerator
+      def to_enum
+        s9_xdm_value.each.lazy.map { |s9_xdm_item|
+          XDM.Item(s9_xdm_item)
+        }.each
+      end
+
+      alias_method :enum_for, :to_enum
+
+      def sequence_enum
+        to_enum
+      end
+
+      def sequence_size
+        s9_xdm_value.size
       end
     end
 
-    attr_reader :s9_xdm_value
-    private :s9_xdm_value
+    # Placeholder class for Saxon Items that we haven't gotten to yet
+    class XDM::UnhandledItem
+      def initialize(s9_xdm_item)
+        @s9_xdm_item = s9_xdm_item
+      end
 
-    # @api private
-    def initialize(s9_xdm_value)
-      @s9_xdm_value = s9_xdm_value
-    end
-
-    # @return [Fixnum] The size of the sequence
-    def size
-      s9_xdm_value.size
-    end
-
-    # Calls the given block once for each Item in the sequence, passing that
-    # item as a parameter. Returns the value itself.
-    #
-    # If no block is given, an Enumerator is returned.
-    #
-    # @overload
-    #   @yield [item] The current XDM Item
-    #   @yieldparam item [Saxon::XDM::AtomicValue, Saxon::XDM::Node] the item.
-    def each(&block)
-      to_enum.each(&block)
-    end
-
-    # @return [Saxon::S9API::XdmValue] The underlying Saxon Java XDM valuee object.
-    def to_java
-      @s9_xdm_value
-    end
-
-    # Compare this XDM::Value with another. Currently this requires iterating
-    # across the sequence, and the other sequence and comparing each member
-    # with the corresponding member in the other sequence.
-    #
-    # @param other [Saxon::XDM::Value] The XDM::Value to be compare against
-    # @return [Boolean] whether the two XDM::Values are equal
-    def ==(other)
-      return false unless other.is_a?(XDM::Value)
-      return false unless other.size == size
-      not_okay = to_enum.zip(other.to_enum).find { |mine, theirs|
-        mine != theirs
-      }
-      not_okay.nil? || !not_okay
-    end
-
-    alias_method :eql?, :==
-
-    # The hash code for the XDM::Value
-    # @return [Fixnum] The hash code
-    def hash
-      @hash ||= to_a.hash
-    end
-
-    # Returns a lazy Enumerator over the sequence
-    # @return [Enumerator::Lazy] the enumerator
-    def to_enum
-      s9_xdm_value.each.lazy.map { |s9_xdm_item|
-        XDM.Item(s9_xdm_item)
-      }.each
-    end
-
-    alias_method :enum_for, :to_enum
-
-    def sequence_enum
-      to_enum
-    end
-
-    def sequence_size
-      s9_xdm_value.size
+      def to_java
+        @s9_xdm_item
+      end
     end
   end
-
-  # Placeholder class for Saxon Items that we haven't gotten to yet
-  class XDM::UnhandledItem
-    def initialize(s9_xdm_item)
-      @s9_xdm_item = s9_xdm_item
-    end
-
-    def to_java
-      @s9_xdm_item
-    end
-  end
-end
 end

--- a/lib/saxon/xdm/value.rb
+++ b/lib/saxon/xdm/value.rb
@@ -115,7 +115,7 @@ module Saxon
       # Returns a lazy Enumerator over the sequence
       # @return [Enumerator::Lazy] the enumerator
       def to_enum
-        s9_xdm_value.each.lazy.map { |s9_xdm_item|
+        s9_xdm_value.to_enum.lazy.map { |s9_xdm_item|
           XDM.Item(s9_xdm_item)
         }.each
       end

--- a/lib/saxon/xdm/value.rb
+++ b/lib/saxon/xdm/value.rb
@@ -115,7 +115,7 @@ module Saxon
       # Returns a lazy Enumerator over the sequence
       # @return [Enumerator::Lazy] the enumerator
       def to_enum
-        s9_xdm_value.to_enum.lazy.map { |s9_xdm_item|
+        s9_xdm_value.enum_for(:each).lazy.map { |s9_xdm_item|
           XDM.Item(s9_xdm_item)
         }.each
       end

--- a/lib/saxon/xpath/executable.rb
+++ b/lib/saxon/xpath/executable.rb
@@ -1,5 +1,4 @@
-require_relative '../xdm/node'
-require_relative '../xdm/atomic_value'
+require_relative '../xdm'
 
 module Saxon
   module XPath
@@ -25,7 +24,7 @@ module Saxon
         selector = to_java.load
         selector.setContextItem(context_item.to_java)
         variables.each do |qname_or_string, value|
-          selector.setVariable(static_context.resolve_variable_qname(qname_or_string).to_java, Saxon::XDM::AtomicValue.create(value).to_java)
+          selector.setVariable(static_context.resolve_variable_qname(qname_or_string).to_java, Saxon::XDM.Value(value).to_java)
         end
         Result.new(selector.iterator)
       end

--- a/lib/saxon/xpath/executable.rb
+++ b/lib/saxon/xpath/executable.rb
@@ -1,5 +1,5 @@
-require_relative '../xdm_node'
-require_relative '../xdm_atomic_value'
+require_relative '../xdm/node'
+require_relative '../xdm/atomic_value'
 
 module Saxon
   module XPath
@@ -18,14 +18,14 @@ module Saxon
       end
 
       # Run the compiled query using a passed-in node as the context item.
-      # @param context_item [Saxon::XdmNode] the context item node
+      # @param context_item [Saxon::XDM::Node] the context item node
       # @return [Saxon::XPath::Result] the result of the query as an
       #   enumerable
       def run(context_item, variables = {})
         selector = to_java.load
         selector.setContextItem(context_item.to_java)
         variables.each do |qname_or_string, value|
-          selector.setVariable(static_context.resolve_variable_qname(qname_or_string).to_java, Saxon::XdmAtomicValue.create(value).to_java)
+          selector.setVariable(static_context.resolve_variable_qname(qname_or_string).to_java, Saxon::XDM::AtomicValue.create(value).to_java)
         end
         Result.new(selector.iterator)
       end
@@ -48,11 +48,11 @@ module Saxon
         @result_iterator = result_iterator
       end
 
-      # Yields <tt>XdmNode</tt>s from the query result. If no block is passed,
-      # returns an <tt>Enumerator</tt> 
-      # @yieldparam xdm_node [Saxon::XdmNode] the name that is yielded
+      # Yields <tt>XDM::Node</tt>s from the query result. If no block is passed,
+      # returns an <tt>Enumerator</tt>
+      # @yieldparam xdm_node [Saxon::XDM::Node] the name that is yielded
       def each(&block)
-        @result_iterator.lazy.map { |s9_xdm_node| Saxon::XdmNode.new(s9_xdm_node) }.each(&block)
+        @result_iterator.lazy.map { |s9_xdm_node| Saxon::XDM::Node.new(s9_xdm_node) }.each(&block)
       end
     end
   end

--- a/lib/saxon/xslt/compiler.rb
+++ b/lib/saxon/xslt/compiler.rb
@@ -38,8 +38,8 @@ module Saxon
       # @!attribute [r] default_collation
       #   @return [String] the URI of the default declared collation
       # @!attribute [r] static_parameters
-      #   @return [Hash<Saxon::QName => Saxon::XdmValue, Saxon::XdmNode,
-      #   Saxon::XdmAtomicValue>] parameters required at compile time as QName => value hash
+      #   @return [Hash<Saxon::QName => Saxon::XDM::Value, Saxon::XDM::Node,
+      #   Saxon::XDM::AtomicValue>] parameters required at compile time as QName => value hash
 
       # @param source [Saxon::Source] the Source to compile
       # @return [Saxon::XSLT::Executable] the executable stylesheet

--- a/lib/saxon/xslt/evaluation_context.rb
+++ b/lib/saxon/xslt/evaluation_context.rb
@@ -11,7 +11,7 @@ module Saxon
         # @param args [Hash]
         # @option args [String] default_collation URI of the default collation
         # @option args [Hash<String,Symbol,Saxon::QName =>
-        #   Object,Saxon::XdmValue] static_parameters Hash of QName => value
+        #   Object,Saxon::XDM::Value] static_parameters Hash of QName => value
         #   bindings for static (compile-time) parameters for this compiler
         def initialize(args = {})
           @default_collation = args.fetch(:default_collation, nil).freeze
@@ -76,13 +76,13 @@ module Saxon
         # compile-time to avoid an error), as a hash of QName => Value pairs.
         # Parameter QNames can be declared as Strings or Symbols if they are
         # not in any namespace, otherwise an explicit {Saxon::QName} must be
-        # used. Values can be provided as explicit XdmValues:
-        # {Saxon::XdmValue}, {Saxon::XdmNode}, and {Saxon::XdmAtomicValue}, or
-        # as Ruby objects which will be converted to {Saxon::XdmAtomicValue}s
+        # used. Values can be provided as explicit XDM::Values:
+        # {Saxon::XDM::Value}, {Saxon::XDM::Node}, and {Saxon::XDM::AtomicValue}, or
+        # as Ruby objects which will be converted to {Saxon::XDM::AtomicValue}s
         # in the usual way.
         #
         # @param parameters [Hash<String,Symbol,Saxon::QName =>
-        #   Object,Saxon::XdmValue>] Hash of QName => value
+        #   Object,Saxon::XDM::Value>] Hash of QName => value
         def static_parameters(parameters = {})
           @static_parameters = @static_parameters.merge(process_parameters(parameters)).freeze
         end
@@ -92,7 +92,7 @@ module Saxon
         # @see EvaluationContext#static_parameters for details of the argument format
         #
         # @param parameters [Hash<String,Symbol,Saxon::QName =>
-        #   Object,Saxon::XdmValue>] Hash of QName => value
+        #   Object,Saxon::XDM::Value>] Hash of QName => value
         def global_parameters(parameters = {})
           @global_parameters = @global_parameters.merge(process_parameters(parameters)).freeze
         end
@@ -104,7 +104,7 @@ module Saxon
         # @see EvaluationContext#static_parameters for details of the argument format
         #
         # @param parameters [Hash<String,Symbol,Saxon::QName =>
-        #   Object,Saxon::XdmValue>] Hash of QName => value
+        #   Object,Saxon::XDM::Value>] Hash of QName => value
         def initial_template_parameters(parameters = {})
           @initial_template_parameters = @initial_template_parameters.merge(process_parameters(parameters))
         end
@@ -116,7 +116,7 @@ module Saxon
         # @see EvaluationContext#static_parameters for details of the argument format
         #
         # @param parameters [Hash<String,Symbol,Saxon::QName =>
-        #   Object,Saxon::XdmValue>] Hash of QName => value
+        #   Object,Saxon::XDM::Value>] Hash of QName => value
         def initial_template_tunnel_parameters(parameters = {})
           @initial_template_tunnel_parameters = @initial_template_tunnel_parameters.merge(process_parameters(parameters))
         end
@@ -159,10 +159,10 @@ module Saxon
 
       def self.process_xdm_value(value)
         case value
-        when Saxon::XdmValue, Saxon::XdmNode, Saxon::XdmAtomicValue
+        when Saxon::XDM::Value, Saxon::XDM::Node, Saxon::XDM::AtomicValue
           value
         else
-          Saxon::XdmAtomicValue.create(value)
+          Saxon::XDM::AtomicValue.create(value)
         end
       end
 

--- a/lib/saxon/xslt/evaluation_context.rb
+++ b/lib/saxon/xslt/evaluation_context.rb
@@ -153,17 +153,8 @@ module Saxon
     module ParameterHelper
       def self.process_parameters(parameters)
         Hash[parameters.map { |qname, value|
-          [Saxon::QName.resolve(qname), process_xdm_value(value)]
+          [Saxon::QName.resolve(qname), Saxon::XDM.Value(value)]
         }]
-      end
-
-      def self.process_xdm_value(value)
-        case value
-        when Saxon::XDM::Value, Saxon::XDM::Node, Saxon::XDM::AtomicValue
-          value
-        else
-          Saxon::XDM::AtomicValue.create(value)
-        end
       end
 
       def self.to_java(parameters)

--- a/lib/saxon/xslt/executable.rb
+++ b/lib/saxon/xslt/executable.rb
@@ -1,7 +1,7 @@
 require 'forwardable'
 require_relative 'evaluation_context'
 require_relative '../serializer'
-require_relative '../xdm_value'
+require_relative '../xdm/value'
 require_relative '../qname'
 
 module Saxon
@@ -111,7 +111,7 @@ module Saxon
       end
 
       def result_xdm_value(transformer_return_value)
-        XdmValue.wrap_s9_xdm_value(
+        XDM::Value.wrap_s9_xdm_value(
           transformer_return_value.nil? ? destination.getXdmNode : transformer_return_value
         )
       end

--- a/lib/saxon/xslt/executable.rb
+++ b/lib/saxon/xslt/executable.rb
@@ -1,7 +1,7 @@
 require 'forwardable'
 require_relative 'evaluation_context'
 require_relative '../serializer'
-require_relative '../xdm/value'
+require_relative '../xdm'
 require_relative '../qname'
 
 module Saxon
@@ -111,7 +111,7 @@ module Saxon
       end
 
       def result_xdm_value(transformer_return_value)
-        XDM::Value.wrap_s9_xdm_value(
+        XDM.Value(
           transformer_return_value.nil? ? destination.getXdmNode : transformer_return_value
         )
       end

--- a/spec/saxon/axis_iterator_spec.rb
+++ b/spec/saxon/axis_iterator_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Saxon::AxisIterator do
   describe "instances" do
     subject { Saxon::AxisIterator.new(xdm_node, :child) }
 
-    specify "yield Saxon::XdmNodes" do
-      expect(subject.each.first).to be_a(Saxon::XdmNode)
+    specify "yield Saxon::XDM::Nodes" do
+      expect(subject.each.first).to be_a(Saxon::XDM::Node)
     end
 
     specify "can return an Array" do

--- a/spec/saxon/document_builder_spec.rb
+++ b/spec/saxon/document_builder_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Saxon::DocumentBuilder do
       source = Saxon::Source.from_string("<doc/>", base_uri: "http://example.org/")
       doc = subject.build(source)
 
-      expect(doc).to be_a(Saxon::XdmNode)
+      expect(doc).to be_a(Saxon::XDM::Node)
     end
   end
 end

--- a/spec/saxon/item_type_spec.rb
+++ b/spec/saxon/item_type_spec.rb
@@ -336,7 +336,7 @@ module Saxon
         ].each do |type_name, lexical_string, expected|
           specify "generate an appropriate Ruby value of class #{expected.class.name} from the XDM type #{type_name}" do
             item_type = described_class.get_type(type_name)
-            value = Saxon::XdmAtomicValue.from_lexical_string(lexical_string, item_type)
+            value = Saxon::XDM::AtomicValue.from_lexical_string(lexical_string, item_type)
             ruby_value = item_type.ruby_value(value)
 
             expect(ruby_value).to eq(expected)
@@ -347,7 +347,7 @@ module Saxon
         specify "return a Saxon::QName for an XDM Atomic Value containing a QName" do
           item_type = described_class.get_type('xs:QName')
           qname = Saxon::QName.clark('{http://example.org/#ns}el')
-          value = Saxon::XdmAtomicValue.create(qname)
+          value = Saxon::XDM::AtomicValue.create(qname)
 
           expect(item_type.ruby_value(value)).to eq(qname)
         end
@@ -355,7 +355,7 @@ module Saxon
         context "encoded binary datatypes return an ASCII-8bit encoded string" do
           specify "from an xs:base64Binary" do
             item_type = described_class.get_type('xs:base64Binary')
-            value = Saxon::XdmAtomicValue.from_lexical_string('ZGVjb2RlZCBieXRlcw==', item_type)
+            value = Saxon::XDM::AtomicValue.from_lexical_string('ZGVjb2RlZCBieXRlcw==', item_type)
             ruby_value = item_type.ruby_value(value)
 
             expect(ruby_value).to eq('decoded bytes')
@@ -364,7 +364,7 @@ module Saxon
 
           specify "from an xs:hexBinary" do
             item_type = described_class.get_type('xs:hexBinary')
-            value = Saxon::XdmAtomicValue.from_lexical_string('6465636f646564206279746573', item_type)
+            value = Saxon::XDM::AtomicValue.from_lexical_string('6465636f646564206279746573', item_type)
             ruby_value = item_type.ruby_value(value)
 
             expect(ruby_value).to eq('decoded bytes')
@@ -373,7 +373,7 @@ module Saxon
 
           specify "from an xs:byte" do
             item_type = described_class.get_type('xs:byte')
-            value = Saxon::XdmAtomicValue.from_lexical_string('-110', item_type)
+            value = Saxon::XDM::AtomicValue.from_lexical_string('-110', item_type)
             ruby_value = item_type.ruby_value(value)
 
             expect(ruby_value).to eq("\x92".force_encoding(Encoding::ASCII_8BIT))
@@ -382,7 +382,7 @@ module Saxon
 
           specify "from an xs:unsignedByte" do
             item_type = described_class.get_type('xs:unsignedByte')
-            value = Saxon::XdmAtomicValue.from_lexical_string('180', item_type)
+            value = Saxon::XDM::AtomicValue.from_lexical_string('180', item_type)
             ruby_value = item_type.ruby_value(value)
 
             expect(ruby_value).to eq("\xb4".force_encoding(Encoding::ASCII_8BIT))

--- a/spec/saxon/serializer_spec.rb
+++ b/spec/saxon/serializer_spec.rb
@@ -60,21 +60,21 @@ RSpec.describe Saxon::Serializer do
       context "to an IO-like" do
         let(:io) { StringIO.new }
 
-        it "writes an XdmNode" do
+        it "writes an XDM::Node" do
           subject.serialize(xdm_node, io)
 
           expect(io.string).to eq('<?xml version="1.0" encoding="UTF-8"?><doc/>')
         end
 
-        xit "writes an XdmValue" do
+        xit "writes an XDM::Value" do
         end
 
-        xit "writes an XdmItem" do
+        xit "writes an XDM::Item" do
         end
       end
 
       context "to a string" do
-        it "writes an XdmNode" do
+        it "writes an XDM::Node" do
           expect(subject.serialize(xdm_node)).to eq(
             '<?xml version="1.0" encoding="UTF-8"?><doc/>'
           )
@@ -88,15 +88,15 @@ RSpec.describe Saxon::Serializer do
           expect(result).to eq('<?xml version="1.0" encoding="UTF-16"?><doc/>'.encode(Encoding::UTF_16))
         end
 
-        xit "writes an XdmValue" do
+        xit "writes an XDM::Value" do
         end
 
-        xit "writes an XdmItem" do
+        xit "writes an XDM::Item" do
         end
       end
 
       context "to a file path" do
-        it "writes an XdmNode" do
+        it "writes an XDM::Node" do
           Dir.mktmpdir do |dir|
             path = File.join(dir, 'f.xml')
 
@@ -106,10 +106,10 @@ RSpec.describe Saxon::Serializer do
           end
         end
 
-        xit "writes an XdmValue" do
+        xit "writes an XDM::Value" do
         end
 
-        xit "writes an XdmItem" do
+        xit "writes an XDM::Item" do
         end
       end
     end

--- a/spec/saxon/xdm/array_spec.rb
+++ b/spec/saxon/xdm/array_spec.rb
@@ -54,6 +54,12 @@ module Saxon
           expect(subject.hash).to eq(a2.hash)
         end
       end
+
+      context "immutability" do
+        specify "the Ruby array we use to hold the wrapped array cannot be altered" do
+          expect { subject.to_a.append(1) }.to raise_error(FrozenError)
+        end
+      end
     end
   end
 end

--- a/spec/saxon/xdm/array_spec.rb
+++ b/spec/saxon/xdm/array_spec.rb
@@ -9,7 +9,12 @@ module Saxon
           expect(described_class.create([1,2]).to_a).to eq([XDM.AtomicValue(1), XDM.AtomicValue(2)])
         end
 
-        specify "an array containing "
+        specify "an array containing nested arrays becomes an XDM Array of XDM Values" do
+          expect(described_class.create([[1,2], [3,4]]).to_a).to eq([
+            XDM.Value([1,2]),
+            XDM.Value([3,4])
+          ])
+        end
       end
     end
 
@@ -23,6 +28,31 @@ module Saxon
 
       specify "acts as an Enumerable" do
         expect(subject.each.to_a).to eq([XDM.AtomicValue(s9_xdm_atomic_value)])
+      end
+
+      specify "returns the size of the array" do
+        expect(subject.length).to eq(1)
+        expect(subject.size).to eq(1)
+      end
+
+      specify "elements can be accessed using []" do
+        expect(subject[0]).to eq(XDM.AtomicValue(1))
+      end
+
+      context "when compared, XDM Arrays" do
+        let(:a2) { described_class.create([XDM.AtomicValue(S9API::XdmAtomicValue.new(1))]) }
+
+        specify "are #== equal to another instance representing the same array of values" do
+          expect(subject == a2).to be(true)
+        end
+
+        specify "are #eql? equal to another instance representing the same array of values" do
+          expect(subject.eql?(a2)).to be(true)
+        end
+
+        specify "have the same hash as another instance representing the same array of values" do
+          expect(subject.hash).to eq(a2.hash)
+        end
       end
     end
   end

--- a/spec/saxon/xdm/array_spec.rb
+++ b/spec/saxon/xdm/array_spec.rb
@@ -1,0 +1,29 @@
+require 'saxon/xdm'
+require_relative 'sequence_like_examples'
+
+module Saxon
+  RSpec.describe XDM::Array do
+    context "creation" do
+      context "from Ruby Arrays" do
+        specify "an array of simple values gets correctly created" do
+          expect(described_class.create([1,2]).to_a).to eq([XDM.AtomicValue(1), XDM.AtomicValue(2)])
+        end
+
+        specify "an array containing "
+      end
+    end
+
+    context "instances" do
+      let(:s9_xdm_atomic_value) { S9API::XdmAtomicValue.new(1) }
+      let(:s9_xdm_array) { S9API::XdmArray.new([s9_xdm_atomic_value]) }
+      subject { XDM::Array.new(s9_xdm_array) }
+
+      it_should_behave_like "an XDM Value hierarchy sequence-like"
+      it_should_behave_like "an XDM Item hierarchy sequence-like"
+
+      specify "acts as an Enumerable" do
+        expect(subject.each.to_a).to eq([XDM.AtomicValue(s9_xdm_atomic_value)])
+      end
+    end
+  end
+end

--- a/spec/saxon/xdm/atomic_value_spec.rb
+++ b/spec/saxon/xdm/atomic_value_spec.rb
@@ -6,6 +6,19 @@ require_relative 'sequence_like_examples'
 module Saxon
   RSpec.describe XDM::AtomicValue do
     describe "creating from Ruby objects" do
+      specify "handles being passed an existing net.sf.saxon.s9api.XdmAtomicValue correctly" do
+        s9_value = S9API::XdmAtomicValue.new(1)
+        value = described_class.create(s9_value)
+
+        expect(value.to_java).to be(s9_value)
+      end
+
+      specify "handles being passed an existing XDM::AtomicValue correctly" do
+        value = described_class.create(1)
+
+        expect(described_class.create(value)).to be(value)
+      end
+
       context "using primitives" do
         specify "a Ruby String produces an xs:string" do
           value = described_class.create('a')
@@ -164,6 +177,7 @@ module Saxon
       end
 
       it_should_behave_like "an XDM Value hierarchy sequence-like"
+      it_should_behave_like "an XDM Item hierarchy sequence-like"
     end
   end
 end

--- a/spec/saxon/xdm/atomic_value_spec.rb
+++ b/spec/saxon/xdm/atomic_value_spec.rb
@@ -1,9 +1,9 @@
-require 'saxon/xdm_atomic_value'
+require 'saxon/xdm/atomic_value'
 require 'saxon/qname'
 require 'saxon/item_type'
 
 module Saxon
-  RSpec.describe XdmAtomicValue do
+  RSpec.describe XDM::AtomicValue do
     describe "creating from Ruby objects" do
       context "using primitives" do
         specify "a Ruby String produces an xs:string" do
@@ -90,7 +90,7 @@ module Saxon
           specify "explicit lexical form creation is prevented in the class" do
             expect {
               described_class.from_lexical_string('name', 'xs:QName')
-            }.to raise_error(XdmAtomicValue::CannotCreateQNameFromString)
+            }.to raise_error(XDM::AtomicValue::CannotCreateQNameFromString)
           end
         end
 
@@ -101,13 +101,13 @@ module Saxon
           specify "cannot be created by passing a Saxon::QName and explicit type" do
             expect {
               described_class.create(qname, 'xs:NOTATION')
-            }.to raise_error(XdmAtomicValue::NotationCannotBeDirectlyCreated)
+            }.to raise_error(XDM::AtomicValue::NotationCannotBeDirectlyCreated)
           end
 
           specify "does not allow creation via string/explicit type name" do
             expect {
               described_class.create('name', 'xs:NOTATION')
-            }.to raise_error(XdmAtomicValue::NotationCannotBeDirectlyCreated)
+            }.to raise_error(XDM::AtomicValue::NotationCannotBeDirectlyCreated)
           end
         end
       end

--- a/spec/saxon/xdm/atomic_value_spec.rb
+++ b/spec/saxon/xdm/atomic_value_spec.rb
@@ -1,6 +1,7 @@
-require 'saxon/xdm/atomic_value'
+require 'saxon/xdm'
 require 'saxon/qname'
 require 'saxon/item_type'
+require_relative 'sequence_like_examples'
 
 module Saxon
   RSpec.describe XDM::AtomicValue do
@@ -161,6 +162,8 @@ module Saxon
           expect(value.to_s).to eq('1')
         end
       end
+
+      it_should_behave_like "an XDM Value hierarchy sequence-like"
     end
   end
 end

--- a/spec/saxon/xdm/empty_sequence_spec.rb
+++ b/spec/saxon/xdm/empty_sequence_spec.rb
@@ -18,15 +18,15 @@ RSpec.describe Saxon::XDM::EmptySequence do
     context "all instances compare equal" do
       let(:other) { described_class.new }
 
-      specify "are #== equal to another instance representing the same node" do
+      specify "are #== equal to another instance" do
         expect(subject == other).to be(true)
       end
 
-      specify "are #eql? equal to another instance representing the same node" do
+      specify "are #eql? equal to another instance" do
         expect(subject.eql?(other)).to be(true)
       end
 
-      specify "have the same hash as another instance representing the same node" do
+      specify "have the same hash as another instance" do
         expect(subject.hash).to eq(other.hash)
       end
     end

--- a/spec/saxon/xdm/empty_sequence_spec.rb
+++ b/spec/saxon/xdm/empty_sequence_spec.rb
@@ -1,0 +1,40 @@
+require 'saxon/xdm'
+require_relative 'sequence_like_examples'
+
+RSpec.describe Saxon::XDM::EmptySequence do
+  describe "instances" do
+    it "returns the underlying Java XdmEmptySequence" do
+      expect(subject.to_java).to be_a(Saxon::S9API::XdmEmptySequence)
+    end
+
+    it "sequence_enum returns an empty enum" do
+      expect(subject.sequence_enum.to_a).to eq([])
+    end
+
+    it "sequence_size returns 0" do
+      expect(subject.sequence_size).to eq(0)
+    end
+
+    context "all instances compare equal" do
+      let(:other) { described_class.new }
+
+      specify "are #== equal to another instance representing the same node" do
+        expect(subject == other).to be(true)
+      end
+
+      specify "are #eql? equal to another instance representing the same node" do
+        expect(subject.eql?(other)).to be(true)
+      end
+
+      specify "have the same hash as another instance representing the same node" do
+        expect(subject.hash).to eq(other.hash)
+      end
+    end
+
+    it_should_behave_like "an XDM Value hierarchy sequence-like"
+  end
+
+  specify ".create returns a cached instance" do
+    expect(described_class.create).to be(described_class.create)
+  end
+end

--- a/spec/saxon/xdm/external_object_spec.rb
+++ b/spec/saxon/xdm/external_object_spec.rb
@@ -1,0 +1,14 @@
+require 'saxon/xdm'
+require_relative 'sequence_like_examples'
+
+module Saxon
+  RSpec.describe XDM::ExternalObject do
+    let(:s9_xdm_external_object) { S9API::XdmExternalObject.new(1) }
+    subject { described_class.new(s9_xdm_external_object) }
+
+    context "instances" do
+      it_should_behave_like "an XDM Value hierarchy sequence-like"
+      it_should_behave_like "an XDM Item hierarchy sequence-like"
+    end
+  end
+end

--- a/spec/saxon/xdm/function_item_spec.rb
+++ b/spec/saxon/xdm/function_item_spec.rb
@@ -1,0 +1,24 @@
+require 'saxon/processor'
+require 'saxon/xdm'
+require_relative 'sequence_like_examples'
+
+module Saxon
+  RSpec.describe XDM::FunctionItem do
+    requires_pe do
+      let(:processor) { Saxon::Processor.create }
+      let(:s9_function_item) {
+        Saxon::S9API::XdmFunctionItem.getSystemFunction(
+          processor.to_java,
+          Saxon::QName.clark('{http://www.w3.org/2005/xpath-functions}path').to_java,
+          1
+        )
+      }
+      subject { described_class.new(s9_function_item) }
+
+      context "instances" do
+        it_should_behave_like "an XDM Value hierarchy sequence-like"
+        it_should_behave_like "an XDM Item hierarchy sequence-like"
+      end
+    end
+  end
+end

--- a/spec/saxon/xdm/item_spec.rb
+++ b/spec/saxon/xdm/item_spec.rb
@@ -1,6 +1,7 @@
 require 'saxon/processor'
 require 'saxon/source'
 require 'saxon/xdm'
+require 'set'
 
 module Saxon
   RSpec.describe XDM do
@@ -9,37 +10,39 @@ module Saxon
       let(:source) { Saxon::Source.from_string("<doc/>", base_uri: "http://example.org/") }
       let(:doc_node) { doc_builder.build(source) }
 
-      specify "s9api.XdmValue creates an XDM::Value" do
-        s9_value = S9API::XdmValue.new([])
-        expect(XDM.Item(s9_value)).to be_a(XDM::Value)
-      end
+      context "s9api Java Xdm* objects" do
+        specify "s9api.XdmValue creates an XDM::Value" do
+          s9_value = S9API::XdmValue.new([])
+          expect(XDM.Item(s9_value)).to be_a(XDM::Value)
+        end
 
-      specify "s9api.XdmAtomicValue creates an XDM::AtomicValue" do
-        s9_value = S9API::XdmAtomicValue.new(1)
-        expect(XDM.Item(s9_value)).to be_a(XDM::AtomicValue)
-      end
+        specify "s9api.XdmAtomicValue creates an XDM::AtomicValue" do
+          s9_value = S9API::XdmAtomicValue.new(1)
+          expect(XDM.Item(s9_value)).to be_a(XDM::AtomicValue)
+        end
 
-      specify "s9api.XdmNode creates an XDM::Node" do
-        expect(XDM.Item(doc_node.to_java)).to be_a(XDM::Node)
-      end
+        specify "s9api.XdmNode creates an XDM::Node" do
+          expect(XDM.Item(doc_node.to_java)).to be_a(XDM::Node)
+        end
 
-      specify "s9api.XdmExternalObject creates an XDM::ExternalObject" do
-        s9_value = S9API::XdmExternalObject.new(1)
-        expect(XDM.Item(s9_value)).to be_a(XDM::ExternalObject)
-      end
+        specify "s9api.XdmExternalObject creates an XDM::ExternalObject" do
+          s9_value = S9API::XdmExternalObject.new(1)
+          expect(XDM.Item(s9_value)).to be_a(XDM::ExternalObject)
+        end
 
-      specify "s9api.XdmArray creates an XDM::Array" do
-        s9_value = S9API::XdmArray.new()
-        expect(XDM.Item(s9_value)).to be_a(XDM::Array)
-      end
+        specify "s9api.XdmArray creates an XDM::Array" do
+          s9_value = S9API::XdmArray.new()
+          expect(XDM.Item(s9_value)).to be_a(XDM::Array)
+        end
 
-      specify "s9api.XdmMap creates an XDM::Map" do
-        s9_value = S9API::XdmMap.new()
-        expect(XDM.Item(s9_value)).to be_a(XDM::Map)
-      end
+        specify "s9api.XdmMap creates an XDM::Map" do
+          s9_value = S9API::XdmMap.new()
+          expect(XDM.Item(s9_value)).to be_a(XDM::Map)
+        end
 
-      requires_pe do
-        specify "s9api.XdmFunctionItem creates an XDM::FunctionItem" do
+        requires_pe do
+          specify "s9api.XdmFunctionItem creates an XDM::FunctionItem" do
+          end
         end
       end
 
@@ -52,6 +55,24 @@ module Saxon
 
         specify "XDM Nodes should be passed through unchanged" do
           expect(XDM.Item(doc_node)).to be(doc_node)
+        end
+      end
+
+      context "ruby values" do
+        specify "a plain ruby object gets turned into an XDM::AtomicValue" do
+          expect(XDM.Item(1)).to eq(XDM.AtomicValue(1))
+        end
+
+        specify "an Array gets turned into an XDM::Array" do
+          expect(XDM.Item([1,2])).to eq(XDM.Array([1,2]))
+        end
+
+        specify "a Hash gets turned into an XDM::Map" do
+          expect(XDM.Item({'a' => 1})).to eq(XDM.Map({'a' => 1}))
+        end
+
+        specify "an enumerable gets turned into an XDM::Array" do
+          expect(XDM.Item(Set.new([1,2]))).to eq(XDM.Array([1,2]))
         end
       end
     end

--- a/spec/saxon/xdm/item_spec.rb
+++ b/spec/saxon/xdm/item_spec.rb
@@ -1,0 +1,59 @@
+require 'saxon/processor'
+require 'saxon/source'
+require 'saxon/xdm'
+
+module Saxon
+  RSpec.describe XDM do
+    context "creating Ruby wrapper objects from XDM items and Ruby values" do
+      let(:doc_builder) { Saxon::Processor.create.document_builder }
+      let(:source) { Saxon::Source.from_string("<doc/>", base_uri: "http://example.org/") }
+      let(:doc_node) { doc_builder.build(source) }
+
+      specify "s9api.XdmValue creates an XDM::Value" do
+        s9_value = S9API::XdmValue.new([])
+        expect(XDM.Item(s9_value)).to be_a(XDM::Value)
+      end
+
+      specify "s9api.XdmAtomicValue creates an XDM::AtomicValue" do
+        s9_value = S9API::XdmAtomicValue.new(1)
+        expect(XDM.Item(s9_value)).to be_a(XDM::AtomicValue)
+      end
+
+      specify "s9api.XdmNode creates an XDM::Node" do
+        expect(XDM.Item(doc_node.to_java)).to be_a(XDM::Node)
+      end
+
+      specify "s9api.XdmExternalObject creates an XDM::ExternalObject" do
+        s9_value = S9API::XdmExternalObject.new(1)
+        expect(XDM.Item(s9_value)).to be_a(XDM::ExternalObject)
+      end
+
+      specify "s9api.XdmArray creates an XDM::Array" do
+        s9_value = S9API::XdmArray.new()
+        expect(XDM.Item(s9_value)).to be_a(XDM::Array)
+      end
+
+      specify "s9api.XdmMap creates an XDM::Map" do
+        s9_value = S9API::XdmMap.new()
+        expect(XDM.Item(s9_value)).to be_a(XDM::Map)
+      end
+
+      requires_pe do
+        specify "s9api.XdmFunctionItem creates an XDM::FunctionItem" do
+        end
+      end
+
+      context "existing XDM::* objects get passed through" do
+        [XDM.AtomicValue(1), XDM.Array([1,2])].each do |xdm_item|
+          specify "#{xdm_item.class.name} should be passed through unchanged" do
+            expect(XDM.Item(xdm_item)).to be(xdm_item)
+          end
+        end
+
+        specify "XDM Nodes should be passed through unchanged" do
+          expect(XDM.Item(doc_node)).to be(doc_node)
+        end
+      end
+    end
+  end
+end

--- a/spec/saxon/xdm/map_spec.rb
+++ b/spec/saxon/xdm/map_spec.rb
@@ -1,0 +1,94 @@
+require 'saxon/xdm'
+require_relative 'sequence_like_examples'
+
+module Saxon
+  RSpec.describe XDM::Map do
+    context "creation" do
+      context "from a Ruby Hash" do
+        specify "a hash of simple values gets correctly created" do
+          hash = {'a' => 1, 'b' => 2}
+          map = XDM::Map.create(hash)
+
+          expect(map.to_java.asImmutableMap.to_hash).to eq({
+            S9API::XdmAtomicValue.new('a') => S9API::XdmAtomicValue.new(1),
+            S9API::XdmAtomicValue.new('b') => S9API::XdmAtomicValue.new(2)
+          })
+        end
+      end
+    end
+
+    context "instances" do
+      subject {
+        described_class.new(S9API::XdmMap.new({
+          S9API::XdmAtomicValue.new('a') => S9API::XdmAtomicValue.new(1)
+        }))
+      }
+
+      context "accessing members using #[]" do
+        specify "works with an XDM::AtomicValue" do
+          expect(subject[XDM.AtomicValue('a')]).to eq(XDM.AtomicValue(1))
+        end
+
+        specify "works with a Ruby value" do
+          expect(subject['a']).to eq(XDM.AtomicValue(1))
+        end
+
+        specify "works with an s9api.XdmAtomicValue" do
+          expect(subject[XDM.AtomicValue('a').to_java]).to eq(XDM.AtomicValue(1))
+        end
+      end
+
+      context "comparison" do
+        specify "two maps compare equal if they have the same keys and values" do
+          map_1 = XDM::Map.create('a' => 1, 'b' => 2)
+          map_2 = XDM::Map.create('a' => 1, 'b' => 2)
+
+          expect(map_1).to eq(map_2)
+        end
+      end
+
+      specify "can be iterated across like Ruby hashes" do
+        akku = []
+        subject.each do |k, v|
+          akku << [k, v]
+        end
+
+        expect(akku).to eq([
+          [XDM.AtomicValue('a'), XDM.AtomicValue(1)]
+        ])
+      end
+
+      context "can be merged with another instance to create a new instance" do
+        let(:map_1) { XDM::Map.create('a' => 1, 'b' => 2) }
+        let(:map_2) { XDM::Map.create('c' => 3, 'd' => 4) }
+
+        specify "which contains all items from both the prior instances" do
+          expect(map_1.merge(map_2)).to eq(XDM::Map.create('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4))
+        end
+
+        specify "in the process which neither prior instances are mutated" do
+          map_3 = map_1.merge(map_2)
+          expect(map_1).to eq(XDM::Map.create('a' => 1, 'b' => 2))
+          expect(map_2).to eq(XDM::Map.create('c' => 3, 'd' => 4))
+        end
+      end
+
+      context "enumerable methods that would return a new hash in Ruby" do
+        subject {
+          XDM::Map.create({'a' => 1, 'b' => 2})
+        }
+
+        specify "#select returns a new Map" do
+          expect(subject.select { |k, v| k == XDM.AtomicValue('a') }).to eq(XDM::Map.create({'a' => 1}))
+        end
+
+        specify "#reject returns a new Map" do
+          expect(subject.reject { |k, v| k == XDM.AtomicValue('a') }).to eq(XDM::Map.create({'b' => 2}))
+        end
+      end
+
+      it_should_behave_like "an XDM Value hierarchy sequence-like"
+      it_should_behave_like "an XDM Item hierarchy sequence-like"
+    end
+  end
+end

--- a/spec/saxon/xdm/map_spec.rb
+++ b/spec/saxon/xdm/map_spec.rb
@@ -7,11 +7,21 @@ module Saxon
       context "from a Ruby Hash" do
         specify "a hash of simple values gets correctly created" do
           hash = {'a' => 1, 'b' => 2}
-          map = XDM::Map.create(hash)
+          map = described_class.create(hash)
 
           expect(map.to_java.asImmutableMap.to_hash).to eq({
             S9API::XdmAtomicValue.new('a') => S9API::XdmAtomicValue.new(1),
             S9API::XdmAtomicValue.new('b') => S9API::XdmAtomicValue.new(2)
+          })
+        end
+
+        specify "a hash of arrays becomes a map of XDM Values" do
+          hash = {'a' => [1, 2], 'b' => [3, 4]}
+          map = described_class.create(hash)
+
+          expect(map.to_h).to eq({
+            XDM.AtomicValue('a') => XDM::Value.create(1, 2),
+            XDM.AtomicValue('b') => XDM::Value.create(3, 4)
           })
         end
       end

--- a/spec/saxon/xdm/map_spec.rb
+++ b/spec/saxon/xdm/map_spec.rb
@@ -48,6 +48,24 @@ module Saxon
         end
       end
 
+      context "accessing members using #fetch" do
+        specify "works as #[] does" do
+          expect(subject.fetch('a')).to eq(XDM.AtomicValue(1))
+        end
+
+        specify "raises KeyError when a non-existent key is fetched without a default value specified" do
+          expect { subject.fetch('b') }.to raise_error(KeyError)
+        end
+
+        specify "returns the default value specified if key is not found" do
+          expect(subject.fetch('b', 2)).to eq(2)
+        end
+
+        specify "returns the block result if block arg given and key not found. Key is handed to block converted to XDM::AtomicValue" do
+          expect(subject.fetch('b') { |key| key }).to eq(XDM.AtomicValue('b'))
+        end
+      end
+
       context "comparison" do
         specify "two maps compare equal if they have the same keys and values" do
           map_1 = XDM::Map.create('a' => 1, 'b' => 2)
@@ -94,6 +112,12 @@ module Saxon
 
         specify "#reject returns a new Map" do
           expect(subject.reject { |k, v| k == XDM.AtomicValue('a') }).to eq(XDM::Map.create({'b' => 2}))
+        end
+      end
+
+      context "immutability" do
+        specify "the Ruby hash we use to hold the wrapped Map cannot be altered" do
+          expect { subject.to_h['a'] = 'b' }.to raise_error(FrozenError)
         end
       end
 

--- a/spec/saxon/xdm/node_spec.rb
+++ b/spec/saxon/xdm/node_spec.rb
@@ -1,9 +1,9 @@
-require 'saxon/xdm_node'
+require 'saxon/xdm/node'
 require 'saxon/processor'
 require 'saxon/source'
 require 'saxon/qname'
 
-RSpec.describe Saxon::XdmNode do
+RSpec.describe Saxon::XDM::Node do
   let(:doc_builder) { Saxon::Processor.create.document_builder }
   let(:source) { Saxon::Source.from_string("<doc/>", base_uri: "http://example.org/") }
   let(:doc_node) { doc_builder.build(source) }
@@ -12,14 +12,14 @@ RSpec.describe Saxon::XdmNode do
     it "parses a document given a Source" do
       doc = doc_builder.build(source)
 
-      expect(doc).to be_a(Saxon::XdmNode)
+      expect(doc).to be_a(Saxon::XDM::Node)
     end
   end
 
   describe "instances" do
     subject { doc_node }
 
-    it "returns the underlying Java XdmNode" do
+    it "returns the underlying Java XDM::Node" do
       expect(subject.to_java).to be_a(Saxon::S9API::XdmNode)
     end
 
@@ -32,7 +32,7 @@ RSpec.describe Saxon::XdmNode do
     end
 
     context "when compared, nodes" do
-      let(:n2) { Saxon::XdmNode.new(subject.to_java) }
+      let(:n2) { Saxon::XDM::Node.new(subject.to_java) }
 
       specify "are #== equal to another instance representing the same node" do
         expect(subject == n2).to be(true)

--- a/spec/saxon/xdm/node_spec.rb
+++ b/spec/saxon/xdm/node_spec.rb
@@ -67,5 +67,6 @@ RSpec.describe Saxon::XDM::Node do
     end
 
     it_should_behave_like "an XDM Value hierarchy sequence-like"
+    it_should_behave_like "an XDM Item hierarchy sequence-like"
   end
 end

--- a/spec/saxon/xdm/node_spec.rb
+++ b/spec/saxon/xdm/node_spec.rb
@@ -1,7 +1,8 @@
-require 'saxon/xdm/node'
+require 'saxon/xdm'
 require 'saxon/processor'
 require 'saxon/source'
 require 'saxon/qname'
+require_relative 'sequence_like_examples'
 
 RSpec.describe Saxon::XDM::Node do
   let(:doc_builder) { Saxon::Processor.create.document_builder }
@@ -64,5 +65,7 @@ RSpec.describe Saxon::XDM::Node do
         expect(subject.node_kind).to eq(:element)
       end
     end
+
+    it_should_behave_like "an XDM Value hierarchy sequence-like"
   end
 end

--- a/spec/saxon/xdm/sequence_like_examples.rb
+++ b/spec/saxon/xdm/sequence_like_examples.rb
@@ -56,3 +56,13 @@ RSpec.shared_examples "an XDM Value hierarchy sequence-like" do
     end
   end
 end
+
+RSpec.shared_examples "an XDM Item hierarchy sequence-like" do
+  specify "sequence_enum yields only self" do
+    expect(subject.sequence_enum.to_a).to eq([subject])
+  end
+
+  specify "sequence_size is 1" do
+    expect(subject.sequence_size).to eq(1)
+  end
+end

--- a/spec/saxon/xdm/sequence_like_examples.rb
+++ b/spec/saxon/xdm/sequence_like_examples.rb
@@ -1,0 +1,58 @@
+RSpec.shared_examples "an XDM Value hierarchy sequence-like" do
+  context "sequence enumeration" do
+    specify "returns an enumerable for #sequence_enum" do
+      expect(subject.sequence_enum).to respond_to(:each)
+    end
+
+    specify "returns the size of the sequence" do
+      expect(subject.sequence_size).to eq(subject.sequence_enum.to_a.size)
+    end
+  end
+
+  context "sequnce appending" do
+    specify "appending itself produces a value with twice as many things in" do
+      old_size = subject.sequence_size
+      appended = subject.append(subject)
+
+      expect(appended).to be_a(Saxon::XDM::Value)
+      expect(appended.sequence_size).to eq(old_size * 2)
+    end
+
+    specify "values are immutable so appending does not mutate them" do
+      old_size = subject.sequence_size
+      appended = subject.append(subject)
+
+      expect(appended).to_not eq(subject)
+      expect(subject.sequence_size).to eq(old_size)
+    end
+
+    specify "appending also works via #<<" do
+      appended = subject << subject
+
+      expect(appended.sequence_size).to eq(subject.sequence_size * 2)
+    end
+
+    specify "appending also works with #+" do
+      appended = subject + subject
+
+      expect(appended.size).to eq(subject.sequence_size * 2)
+    end
+
+    context "appending regular Ruby objects" do
+      specify "causes them to be wrapped as an AtomicValue" do
+        new_value = subject << 1
+
+        expect(new_value.sequence_enum.to_a.last).to eq(Saxon::XDM::AtomicValue.create(1))
+      end
+
+      specify "using an array causes them to be wrapped but doesn't create an XDM::Array" do
+        new_value = subject << [1, 2]
+
+        expect(new_value.sequence_enum.to_a.reverse[0..1]).to eq([
+          Saxon::XDM::AtomicValue.create(2),
+          Saxon::XDM::AtomicValue.create(1)
+        ])
+      end
+    end
+  end
+end

--- a/spec/saxon/xdm/value_spec.rb
+++ b/spec/saxon/xdm/value_spec.rb
@@ -1,48 +1,48 @@
-require 'saxon/xdm_value'
+require 'saxon/xdm/value'
 require 'saxon/processor'
-require 'saxon/xdm_atomic_value'
+require 'saxon/xdm/atomic_value'
 
 module Saxon
-  RSpec.describe XdmValue do
+  RSpec.describe XDM::Value do
     let(:processor) { Saxon::Processor.create }
 
     describe "being created" do
       it "allows the creation of XDM Values from an array of XDM Items" do
-        o1 = XdmAtomicValue.new(1)
-        o2 = XdmAtomicValue.new(2)
+        o1 = XDM::AtomicValue.new(1)
+        o2 = XDM::AtomicValue.new(2)
 
-        value = XdmValue.create([o1, o2])
-        expect(value).to be_a(XdmValue)
+        value = XDM::Value.create([o1, o2])
+        expect(value).to be_a(XDM::Value)
         expect(value.size).to eq(2)
       end
     end
 
-    describe "wrapping Saxon S9API XdmValues" do
+    describe "wrapping Saxon S9API XDM::Values" do
       let(:node) { fixture_doc(processor, 'eg.xml') }
-      let(:atomic_value) { XdmAtomicValue.create(1) }
+      let(:atomic_value) { XDM::AtomicValue.create(1) }
 
-      specify "a single XDM node returns an XdmNode" do
-        expect(XdmValue.wrap_s9_xdm_value(node.to_java)).to be_a(XdmNode)
+      specify "a single XDM node returns an XDM::Node" do
+        expect(XDM::Value.wrap_s9_xdm_value(node.to_java)).to be_a(XDM::Node)
       end
 
-      specify "a single-item sequence returns an XdmValue" do
+      specify "a single-item sequence returns an XDM::Value" do
         sequence = Saxon::S9API::XdmValue.new([atomic_value.to_java])
-        expect(XdmValue.wrap_s9_xdm_value(sequence)).to be_a(XdmValue)
+        expect(XDM::Value.wrap_s9_xdm_value(sequence)).to be_a(XDM::Value)
       end
 
-      specify "a multi-item sequence returns an XdmValue" do
+      specify "a multi-item sequence returns an XDM::Value" do
         sequence = Saxon::S9API::XdmValue.new([atomic_value, atomic_value].map(&:to_java))
-        expect(XdmValue.wrap_s9_xdm_value(sequence)).to be_a(XdmValue)
+        expect(XDM::Value.wrap_s9_xdm_value(sequence)).to be_a(XDM::Value)
       end
 
-      specify "the empty sequence returns an XdmValue" do
+      specify "the empty sequence returns an XDM::Value" do
         sequence = Saxon::S9API::XdmEmptySequence.getInstance
-        expect(XdmValue.wrap_s9_xdm_value(sequence)).to be_a(XdmValue)
+        expect(XDM::Value.wrap_s9_xdm_value(sequence)).to be_a(XDM::Value)
       end
     end
 
     describe "instances" do
-      let(:items) { [1,2,3].map { |v| XdmAtomicValue.create(v) } }
+      let(:items) { [1,2,3].map { |v| XDM::AtomicValue.create(v) } }
       subject { described_class.create(items) }
 
       it "returns the underlying Java XdmValue" do
@@ -61,16 +61,16 @@ module Saxon
 
       context "wrapping member items appropriately" do
         let(:node) { fixture_doc(processor, 'eg.xml') }
-        let(:atomic_value) { XdmAtomicValue.create(1) }
+        let(:atomic_value) { XDM::AtomicValue.create(1) }
 
         subject { described_class.create([node, atomic_value]) }
 
         specify "returns xdm nodes" do
-          expect(subject.to_a[0]).to be_a(Saxon::XdmNode)
+          expect(subject.to_a[0]).to be_a(Saxon::XDM::Node)
         end
 
         specify "returns xdm atomic value" do
-          expect(subject.to_a[1]).to be_a(Saxon::XdmAtomicValue)
+          expect(subject.to_a[1]).to be_a(Saxon::XDM::AtomicValue)
         end
       end
 

--- a/spec/saxon/xdm/value_spec.rb
+++ b/spec/saxon/xdm/value_spec.rb
@@ -56,7 +56,7 @@ module Saxon
       end
 
       context "when handed a single item" do
-        specify "an XDM::Value returns a new itself" do
+        specify "an XDM::Value is returned unchanged" do
           value = XDM::Value.create([atomic_value, node])
 
           expect(XDM::Value.create(value)).to eq(value)

--- a/spec/saxon/xdm/value_spec.rb
+++ b/spec/saxon/xdm/value_spec.rb
@@ -11,6 +11,19 @@ module Saxon
       let(:node) { fixture_doc(processor, 'eg.xml') }
       let(:atomic_value) { XDM.AtomicValue(1) }
 
+      specify "handles being passed an existing net.sf.saxon.s9api.XdmValue correctly" do
+        s9_value = described_class.create([1,2]).to_java
+        value = described_class.create(s9_value)
+
+        expect(value.to_java).to be(s9_value)
+      end
+
+      specify "handles being passed an existing XDM::Value correctly" do
+        value = described_class.create([1,2])
+
+        expect(described_class.create(value)).to be(value)
+      end
+
       context "when handed a multi-item array" do
         it "from an array of XDM Items" do
           o1 = XDM.AtomicValue(1)

--- a/spec/saxon/xslt/compiler_spec.rb
+++ b/spec/saxon/xslt/compiler_spec.rb
@@ -33,14 +33,14 @@ module Saxon
             static_parameters({
               'no_ns_param_1' => 'inferred string type',
               :no_ns_param_2 => 1,
-              QName.clark('{http://example.org/#ns}param') => XdmAtomicValue.create(1.0)
+              QName.clark('{http://example.org/#ns}param') => XDM::AtomicValue.create(1.0)
             })
           }
 
           expect(compiler.static_parameters).to eq({
-            QName.clark('no_ns_param_1') => XdmAtomicValue.create('inferred string type'),
-            QName.clark('no_ns_param_2') => XdmAtomicValue.create(1),
-            QName.clark('{http://example.org/#ns}param') => XdmAtomicValue.create(1.0)
+            QName.clark('no_ns_param_1') => XDM::AtomicValue.create('inferred string type'),
+            QName.clark('no_ns_param_2') => XDM::AtomicValue.create(1),
+            QName.clark('{http://example.org/#ns}param') => XDM::AtomicValue.create(1.0)
           })
         end
       end
@@ -53,7 +53,7 @@ module Saxon
             }
 
             expect(compiler.global_parameters).to eq({
-              QName.clark('a') => XdmAtomicValue.create('string')
+              QName.clark('a') => XDM::AtomicValue.create('string')
             })
           end
 
@@ -73,7 +73,7 @@ module Saxon
           }
 
           expect(compiler.initial_template_parameters).to eq({
-            QName.clark('a') => XdmAtomicValue.create('string')
+            QName.clark('a') => XDM::AtomicValue.create('string')
           })
         end
 
@@ -83,7 +83,7 @@ module Saxon
           }
 
           expect(compiler.initial_template_tunnel_parameters).to eq({
-            QName.clark('a') => XdmAtomicValue.create('string')
+            QName.clark('a') => XDM::AtomicValue.create('string')
           })
         end
       end
@@ -102,8 +102,8 @@ module Saxon
           }
 
           expect(compiler.static_parameters).to eq({
-            Saxon::QName.clark('a') => Saxon::XdmAtomicValue.create(1),
-            Saxon::QName.clark('b') => Saxon::XdmAtomicValue.create(2)
+            Saxon::QName.clark('a') => Saxon::XDM::AtomicValue.create(1),
+            Saxon::QName.clark('b') => Saxon::XDM::AtomicValue.create(2)
           })
 
           expect(compiler.default_collation).to eq('http://example.org/collation')
@@ -116,7 +116,7 @@ module Saxon
           }
 
           expect(compiler.static_parameters).to eq({
-            Saxon::QName.clark('a') => Saxon::XdmAtomicValue.create(2)
+            Saxon::QName.clark('a') => Saxon::XDM::AtomicValue.create(2)
           })
 
           expect(compiler.default_collation).to be_nil
@@ -157,7 +157,7 @@ module Saxon
         }
 
         expect(executable.global_parameters).to eq({
-          Saxon::QName.clark('a') => Saxon::XdmAtomicValue.create(1)
+          Saxon::QName.clark('a') => Saxon::XDM::AtomicValue.create(1)
         })
 
         expect(subject.global_parameters).to eq({})

--- a/spec/saxon/xslt/executable_spec.rb
+++ b/spec/saxon/xslt/executable_spec.rb
@@ -38,7 +38,7 @@ module Saxon::XSLT
           specify "returns a result which provides the output, and gives access to the XDM document node" do
             result = subject.apply_templates(xml_source)
 
-            expect(result.xdm_value).to be_a(Saxon::XdmNode)
+            expect(result.xdm_value).to be_a(Saxon::XDM::Node)
             expect(result.xdm_value.node_kind).to be(:document)
           end
 
@@ -71,7 +71,7 @@ module Saxon::XSLT
           specify "returns a result which provides the raw XDM value" do
             result = subject.apply_templates(xml_source, raw: true)
 
-            expect(result.xdm_value).to be_a(Saxon::XdmNode)
+            expect(result.xdm_value).to be_a(Saxon::XDM::Node)
             expect(result.xdm_value.node_kind).to be(:element)
           end
         end
@@ -85,7 +85,7 @@ module Saxon::XSLT
           specify "returns a result which provides the output, and gives access to the XDM document node" do
             result = subject.call_template(template)
 
-            expect(result.xdm_value).to be_a(Saxon::XdmNode)
+            expect(result.xdm_value).to be_a(Saxon::XDM::Node)
             expect(result.xdm_value.node_kind).to be(:document)
           end
 
@@ -110,7 +110,7 @@ module Saxon::XSLT
           specify "returns a result which provides the raw XDM value" do
             result = subject.call_template(template, raw: true)
 
-            expect(result.xdm_value).to be_a(Saxon::XdmNode)
+            expect(result.xdm_value).to be_a(Saxon::XDM::Node)
             expect(result.xdm_value.node_kind).to be(:element)
           end
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,11 @@ module FixtureHelpers
   end
 end
 
+module SaxonEditionHelpers
+  def requires_pe(&block)
+  end
+end
+
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/fixtures/cassettes'
   c.hook_into :webmock
@@ -44,4 +49,5 @@ RSpec.configure do |config|
   end
 
   config.include FixtureHelpers
+  config.extend SaxonEditionHelpers
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,13 @@ require 'vcr'
 require 'simplecov'
 SimpleCov.start
 
+# Handle loading alternate Saxon JARs for testing
+if ENV['ALTERNATE_SAXON_HOME']
+  puts "Alternate Saxon requested at: #{ENV['ALTERNATE_SAXON_HOME']}"
+  require 'saxon/loader'
+  Saxon::Loader.load!(ENV['ALTERNATE_SAXON_HOME'])
+end
+
 require 'saxon/source'
 
 module FixtureHelpers


### PR DESCRIPTION
Make `XDM::Value`, `Node`, and `AtomicValue` Sequence-like, able to be
appended to to create new, immutable, sequences. (Appending an `AtomicValue`
to an `AtomicValue` creates a `Value` containing both the `AtomicValue`s, for
instance).

Relatedly, the `XDM::Value.create` method is now very liberal in what it
accepts as input, and ensures that the flatness of XDM sequences is
respected.

Add `EmptySequence` wrapper

Add `XDM.Value()`, `.EmptySequence()` `.AtomicValue()` and `.Item()` convenience
functions that wrap `X.create()` (mostly).

Remove duplicated Value handling code in favour of the new convenience
functions.