### PR TITLE
Nokogiri esque convenience functions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,21 @@ jobs:
         name: Bundle Install
         command: bundle check || bundle install
     - run:
-        name: Run the tests
+        name: Install Code Climate Test Reporter
+        command: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+    - run:
+        name: Run the tests, and upload coverage data to Code Climate
         command: |-
+          ./cc-test-reporter before-build
           mkdir -p /tmp/test-results
           bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+          if [ $? -eq 0 ]; then ./cc-test-reporter format-coverage -t simplecov -o "cc-coverage-alt-saxon.json"; fi
+    - persist_to_workspace:
+        root: "~/project"
+        paths:
+        - cc-coverage*
     - store_test_results:
         path: "/tmp/test-results"
     - store_artifacts:
@@ -57,7 +68,11 @@ jobs:
           ./cc-test-reporter before-build
           mkdir -p /tmp/test-results
           bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
-          ./cc-test-reporter after-build -t simplecov --exit-code=$?
+          if [ $? -eq 0 ]; then ./cc-test-reporter format-coverage -t simplecov -o "cc-coverage.json"; fi
+    - persist_to_workspace:
+        root: "~/project"
+        paths:
+        - cc-coverage*
     - store_test_results:
         path: "/tmp/test-results"
     - store_artifacts:
@@ -393,6 +408,23 @@ jobs:
     - store_artifacts:
         path: "/tmp/test-results"
         destination: test-results
+  Report test coverage to Code Climate:
+    docker:
+    - image: circleci/ruby:latest
+    steps:
+    - attach_workspace:
+        at: "/tmp/workspace"
+    - run:
+        name: Install Code Climate Test Reporter
+        command: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+    - run:
+        name: Upload test coverage to Code Climate
+        command: |-
+          find /tmp/workspace -name 'cc-coverage*.json' &&\
+           ./cc-test-reporter sum-coverage /tmp/workspace/cc-coverage*.json &&\
+           ./cc-test-reporter upload-coverage
 workflows:
   version: 2
   build_and_test:
@@ -411,3 +443,7 @@ workflows:
     - JRuby 9.2.10.0-SNAPSHOT-latest, JDK 11
     - JRuby 9.2.10.0-SNAPSHOT-latest, JDK 13 Saxon HE 9.8
     - JRuby 9.2.10.0-SNAPSHOT-latest, JDK 13
+    - Report test coverage to Code Climate:
+        requires:
+        - JRuby 9.2.9.0, JDK 8 Saxon HE 9.8
+        - JRuby 9.2.9.0, JDK 8

--- a/README.md
+++ b/README.md
@@ -1,8 +1,29 @@
-# Saxon
+# saxon-rb – An idiomatic Ruby wrapper for Saxon
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/saxon`. To experiment with that code, run `bin/console` for an interactive prompt.
+`saxon-rb` aims to be a fully-featured idiomatic wrapper for the Saxon XML
+processing and transformation library. Built after several years experience with
+writing, using, and maintaining the `saxon-xslt` XSLT-focussed wrapper,
+`saxon-rb` aims to keep that ease-of-use for those most common cases, while
+making the less-common cases easy as well.
 
-TODO: Delete this and the text above, and describe your gem
+Saxon provides a massive amount of valuable functionality beyond simple XSLT
+compilation and invocation, and a lot of that is very hard to use from Ruby. The
+facilities provided by it, and by the XSLT 2 and 3 specs, rely heavily on the
+XDM values and types system, which `saxon-rb` makes easy to work with.
+
+Parameter creation and passing, are richer and more expressive; results from
+XSLT, or XPath, that aren't just result trees can be worked with directly in
+Ruby.
+
+[![Gem Version](https://badge.fury.io/rb/saxon.svg)](http://badge.fury.io/rb/saxon)
+[![Code Climate](https://codeclimate.com/github/fidothe/saxon-rb/badges/gpa.svg)](https://codeclimate.com/github/fidothe/saxon-rb)
+[![Test Coverage](https://codeclimate.com/github/fidothe/saxon-rb/badges/coverage.svg)](https://codeclimate.com/github/fidothe/saxon-rb/coverage)
+
+You can find Saxon HE at http://saxon.sourceforge.net/ and Saxonica at
+http://www.saxonica.com/
+
+Saxon HE is (c) Michael H. Kay and released under the Mozilla MPL 1.0
+(http://www.mozilla.org/MPL/1.0/)
 
 ## Installation
 
@@ -20,19 +41,83 @@ Or install it yourself as:
 
     $ gem install saxon
 
+## Simple usage
+
+```ruby
+require 'saxon'
+
+transformer = Saxon::Processor.create.xslt_compiler.compile(Saxon::Source.from_path('/path/to/your.xsl'))
+output = transformer.apply_templates(Saxon::Source.from_path('/path/to/your.xml'))
+```
+
 ## Usage
 
-TODO: Write usage instructions here
+### Parse an XML document
+
+Using a default document builder from the default processor:
+
+```ruby
+document_node = Saxon::Processor.create.document_builder.build(Saxon::Source.from_path('/path/to/your.xml'))
+```
+
+### Transform an XML document with XSLT
+
+```ruby
+transformer = Saxon::Processor.create.xslt_compiler.compile(Saxon::Source.from_path('/path/to/your.xsl'))
+
+# Apply templates against a document
+result_1 = transformer.apply_templates(document_node)
+
+# Call a template without a context item to process
+result_2 = transformer.call_template('main-template')
+```
+
+### Run XPath queries against an XML document
+
+It's possible to define namespaces and variables for your XPaths
+
+```ruby
+processor = Saxon::Processor.create
+xpath = processor.xpath_compiler {
+  namespace a: 'http://example.org/a'
+  variable 'a:var', 'xs:string'
+}.compile('//element[@attr = $a:var]')
+
+matches = xpath.run(document_node, {
+  'a:var' => 'the value'
+})
+```
+
+### Use your Saxon PE license and `.jar`s instead of the bundled Saxon HE
+
+```ruby
+require 'saxon-rb'
+
+Saxon::Loader.load!('/path/to/SaxonHE9-9-1-2J') # The folder that contains the .jars, like $SAXON_HOME
+config = Saxon::Configuration.create_licensed('/path/to/saxon.lic')
+processor = Saxon::Processor.create(config)
+
+processor.xslt_compiler...
+```
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run
+`rake spec` to run the tests. You can also run `bin/console` for an interactive
+prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. To
+release a new version, update the version number in `version.rb`, and then run
+`bundle exec rake release`, which will create a git tag for the version, push
+git commits and tags, and push the `.gem` file to
+[rubygems.org](https://rubygems.org).
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/saxon. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at
+https://github.com/fidothe/saxon-rb. This project is intended to be a safe,
+welcoming space for collaboration, and contributors are expected to adhere to
+the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
@@ -40,4 +125,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Saxon project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/saxon/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Saxon-rb project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/fidothe/saxon-rb/blob/master/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Saxon HE is (c) Michael H. Kay and released under the Mozilla MPL 1.0
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'saxon'
+gem 'saxon-rb'
 ```
 
 And then execute:
@@ -39,7 +39,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install saxon
+    $ gem install saxon-rb
 
 ## Simple usage
 
@@ -60,10 +60,20 @@ Using a default document builder from the default processor:
 document_node = Saxon::Processor.create.document_builder.build(Saxon::Source.from_path('/path/to/your.xml'))
 ```
 
+Or
+
+```ruby
+document_node = Saxon.XML('/path/to/your.xml')
+```
+
+
 ### Transform an XML document with XSLT
 
 ```ruby
 transformer = Saxon::Processor.create.xslt_compiler.compile(Saxon::Source.from_path('/path/to/your.xsl'))
+# Or
+transformer = Saxon.XSLT('/path/to/your.xsl')
+
 
 # Apply templates against a document
 result_1 = transformer.apply_templates(document_node)

--- a/lib/saxon.rb
+++ b/lib/saxon.rb
@@ -3,4 +3,9 @@ require_relative 'saxon/processor'
 
 # An idiomatic Ruby wrapper around the Saxon XML processing library.
 module Saxon
+  # Parse an XML document using a vanilla DocumentBuilder from the default Processor
+  # @see Saxon::Processor#XML
+  def self.XML(input, opts = {})
+    Processor.default.XML(input, opts)
+  end
 end

--- a/lib/saxon.rb
+++ b/lib/saxon.rb
@@ -3,9 +3,17 @@ require_relative 'saxon/processor'
 
 # An idiomatic Ruby wrapper around the Saxon XML processing library.
 module Saxon
-  # Parse an XML document using a vanilla DocumentBuilder from the default Processor
+  # Parse an XML document using a vanilla {DocumentBuilder} from the default
+  # {Processor}
   # @see Saxon::Processor#XML
   def self.XML(input, opts = {})
     Processor.default.XML(input, opts)
+  end
+
+  # Compile an XSLT Stylesheet using a new {XSLT::Compiler} from the default
+  # {Processor}
+  # @see Saxon::Processor#XSLT
+  def self.XSLT(input, opts = {}, &block)
+    Processor.default.XSLT(input, opts, &block)
   end
 end

--- a/lib/saxon/nokogiri.rb
+++ b/lib/saxon/nokogiri.rb
@@ -67,7 +67,7 @@ module Saxon
       end
 
       def v1_param_value(value)
-        if /\A(['"]).+\1\z/.match?(value)
+        if /\A(['"]).+\1\z/.match(value)
           value.slice(1..-2)
         else
           value

--- a/lib/saxon/nokogiri.rb
+++ b/lib/saxon/nokogiri.rb
@@ -1,0 +1,78 @@
+require 'saxon/xslt'
+
+module Saxon
+  module XSLT
+    class Executable
+      # Provided for Nokogiri API compatibility. Cannot use many XSLT 2 and 3
+      # features as a result.
+      #
+      # Transform the input document by applying templates as in XSLT 1. All
+      # parameters will be interpreted as Strings
+      #
+      # @param doc_node [Saxon::XDM::Node] the document to transform
+      # @param params [Hash, Array] a Hash of param name => value, or an Array
+      #   of param names and values of the form +['param', 'value', 'param2',
+      #   'value']+. The array must be of an even-numbered length
+      # @return [Saxon::XDM::Value] the result document
+      def transform(doc_node, params = {})
+        apply_templates(doc_node, v1_parameters(params)).xdm_value
+      end
+
+      # Provided for Nokogiri API compatibility. Cannot use many XSLT 2 and 3
+      # features as a result.
+      #
+      # Transform the input document by applying templates as in XSLT 1, and
+      # then serializing the result to a string using the serialization options
+      # set in the XSLT stylesheet's +<xsl:output/>+.
+      #
+      # @param doc_node [Saxon::XDM::Node] the document to transform
+      # @param params [Hash, Array] a Hash of param name => value, or an Array
+      #   of param names and values of the form +['param', 'value', 'param2',
+      #   'value']+. The array must be of an even-numbered length
+      # @return [String] a serialization of the the result document
+      def apply_to(doc_node, params = {})
+        apply_templates(doc_node, v1_parameters(params)).to_s
+      end
+
+      # Provided for Nokogiri API compatibility. Cannot use many XSLT 2 and 3
+      # features as a result.
+      #
+      # Serialize the input document to a string using the serialization options
+      # set in the XSLT stylesheet's +<xsl:output/>+.
+      #
+      # @param doc_node [Saxon::XDM::Node] the document to serialize
+      # @return [String] a serialization of the the input document
+      def serialize(doc_node)
+        s9_transformer = @s9_xslt_executable.load30
+        serializer = Saxon::Serializer.new(s9_transformer.newSerializer)
+        serializer.serialize(doc_node.to_java)
+      end
+
+      private
+
+      def v1_parameters(params = [])
+        v1_params = v1_params_hash(params).map { |qname, value|
+          [Saxon::QName.resolve(qname), Saxon::XDM.AtomicValue(v1_param_value(value))]
+        }.to_h
+        return {} if v1_params.empty?
+        {global_parameters: v1_params}
+      end
+
+      def v1_params_hash(params = [])
+        return params if params.is_a?(Hash)
+        params.each_slice(2).map { |k,v|
+          raise ArgumentError.new("Odd number of values passed as params: #{params}") if v.nil?
+          [k, v]
+        }.to_h
+      end
+
+      def v1_param_value(value)
+        if /\A(['"]).+\1\z/.match?(value)
+          value.slice(1..-2)
+        else
+          value
+        end
+      end
+    end
+  end
+end

--- a/lib/saxon/processor.rb
+++ b/lib/saxon/processor.rb
@@ -76,7 +76,7 @@ module Saxon
     # <tt>Processor</tt>. Sharing <tt>XSLT::Compiler</tt>s across threads is
     # fine as long as the static context is not changed.
     #
-    # @yield An XPath compiler DSL block, see {Saxon::XSLT::Compiler.create}
+    # @yield An XSLT compiler DSL block, see {Saxon::XSLT::Compiler.create}
     # @return [Saxon::XSLT::Compiler] a new XSLT compiler
     def xslt_compiler(&block)
       Saxon::XSLT::Compiler.create(self, &block)
@@ -107,15 +107,27 @@ module Saxon
     # @param input [Saxon::Source, IO, File, String, Pathname, URI] the input to
     #   be turned into a {Source} and parsed.
     # @param opts [Hash] for Source creation. See {Saxon::Source.create}.
-    # @return [Saxon::XDM::Node] The XML document
+    # @return [Saxon::XDM::Node] the XML document
     def XML(input, opts = {})
-      case input
-      when Saxon::Source
-        source = input
-      else
-        source = Source.create(input, opts)
-      end
+      source = Source.create(input, opts)
       document_builder.build(source)
+    end
+
+    # Construct a {Source} containing an XSLT stylesheet, create an
+    # {XSLT::Compiler}, and compile the source, returning the {XSLT::Executable}
+    # produced. If a {Source} is passed as +input+, then it will be passed
+    # through to the compiler and any source-related options in +opts+ will be
+    # ignored.
+    #
+    # @param input [Saxon::Source, IO, File, String, Pathname, URI] the input to
+    #   be turned into a {Source} and parsed.
+    # @param opts [Hash] for Source creation. See {Saxon::Source.create}.
+    # @yield the block is executed as an {XSLT::EvaluationContext::DSL} instance
+    #   and applied to the compiler
+    # @return [Saxon::XSLT::Executable] the XSLT Executable
+    def XSLT(input, opts = {}, &block)
+      source = Source.create(input, opts)
+      xslt_compiler(&block).compile(source)
     end
   end
 end

--- a/lib/saxon/processor.rb
+++ b/lib/saxon/processor.rb
@@ -98,5 +98,24 @@ module Saxon
     def config
       @config ||= Saxon::Configuration.create(self)
     end
+
+    # Create a {DocumentBuilder} and construct a {Source} and parse some XML.
+    # The args are passed to {Saxon::Source.create}, and the returned {Source}
+    # is parsed using {DocumentBuilder#build}. If a {Source} is passed in, parse
+    # that. Any options in +opts+ will be ignored in that case.
+    #
+    # @param input [Saxon::Source, IO, File, String, Pathname, URI] the input to
+    #   be turned into a {Source} and parsed.
+    # @param opts [Hash] for Source creation. See {Saxon::Source.create}.
+    # @return [Saxon::XDM::Node] The XML document
+    def XML(input, opts = {})
+      case input
+      when Saxon::Source
+        source = input
+      else
+        source = Source.create(input, opts)
+      end
+      document_builder.build(source)
+    end
   end
 end

--- a/lib/saxon/qname.rb
+++ b/lib/saxon/qname.rb
@@ -32,7 +32,7 @@ module Saxon
     # it's an instance of the underlying Saxon Java QName, it'll be wrapped
     # into a {Saxon::QName}
     #
-    # If the arg is a string, it's resolved by using {resolve_variable_name}
+    # If the arg is a string, it's resolved by using {resolve_qname_string}
     #
     # @param qname_or_string [String, Symbol, Saxon::QName] the qname to resolve
     # @param namespaces [Hash<String => String>] the set of namespaces as a hash of <tt>"prefix" => "namespace-uri"</tt>

--- a/lib/saxon/source.rb
+++ b/lib/saxon/source.rb
@@ -107,8 +107,7 @@ module Saxon
         base_uri = opts.fetch(:base_uri) { Helpers.base_uri(io) }
         encoding = opts.fetch(:encoding, nil)
         inputstream = Helpers.inputstream(io, encoding)
-        stream_source = Saxon::JAXP::StreamSource.new(inputstream, base_uri)
-        new(stream_source, inputstream)
+        from_inputstream_or_reader(inputstream, base_uri)
       end
 
       # Generate a Saxon::Source given a path to a file
@@ -190,7 +189,9 @@ module Saxon
       # charset="..."?></tt> at the top of the document), then it can be passed
       # as the +:encoding+ option.
       #
-      # @param [IO, File, String, Pathname, URI] io_path_uri_or_string The XML to be parsed
+      # If an existing {Source} is passed in, simply return it.
+      #
+      # @param [Saxon::Source, IO, File, String, Pathname, URI] input The XML to be parsed
       # @param [Hash] opts
       # @option opts [String] :base_uri The Base URI for the Source - an
       #   absolute URI or relative path that will be used to resolve relative
@@ -203,16 +204,18 @@ module Saxon
       #   encoding. Defaults to the <?xml charset="..."?> declaration in the
       #   source.
       # @return [Saxon::Source] the Saxon::Source wrapping the input
-      def create(io_path_uri_or_string, opts = {})
-        case io_path_uri_or_string
+      def create(input, opts = {})
+        case input
+        when Saxon::Source
+          input
         when IO, File, java.io.InputStream, StringIO
-          from_io(io_path_uri_or_string, opts)
+          from_io(input, opts)
         when Pathname, PathChecker
-          from_path(io_path_uri_or_string, opts)
+          from_path(input, opts)
         when URIChecker
-          from_uri(io_path_uri_or_string, opts)
+          from_uri(input, opts)
         else
-          from_string(io_path_uri_or_string, opts)
+          from_string(input, opts)
         end
       end
 

--- a/lib/saxon/xdm.rb
+++ b/lib/saxon/xdm.rb
@@ -9,24 +9,31 @@ require_relative 'xdm/empty_sequence'
 require_relative 'xdm/item'
 
 module Saxon
+  # Classes for representing, creating, and working with the XPath Data Model
+  # type system used in XPath 2+, XSLT 2+, and XQuery.
   module XDM
     class << self
+      # Convenience function for creating a new {AtomicValue}. See {AtomicValue.create}
       def AtomicValue(*args)
         XDM::AtomicValue.create(*args)
       end
 
+      # Convenience function for creating a new {Value}. See {Value.create}
       def Value(*args)
         XDM::Value.create(*args)
       end
 
+      # Returns the XDM {EmptySequence}. See {EmptySequence.create}
       def EmptySequence()
         XDM::EmptySequence.create
       end
 
+      # Convenience function for creating a new {Array}. See {Array.create}
       def Array(*args)
         XDM::Array.create(*args)
       end
 
+      # Convenience function for creating a new {Map}. See {Map.create}
       def Map(*args)
         XDM::Map.create(*args)
       end

--- a/lib/saxon/xdm/atomic_value.rb
+++ b/lib/saxon/xdm/atomic_value.rb
@@ -41,7 +41,7 @@ module Saxon
         # Convert a single Ruby value into an XDM::AtomicValue
         #
         # If no explicit {ItemType} is passed, the correct type is guessed based
-        # on the class of the value. (e.g. <tt>xs:date</tt> for {Date}.)
+        # on the class of the value. (e.g. <tt>xs:date</tt> for {::Date}.)
         #
         # Values are converted based on Ruby idioms and operations, so an explicit
         # {ItemType} of <tt>xs:boolean</tt> will use truthyness to evaluate the

--- a/lib/saxon/xdm/empty_sequence.rb
+++ b/lib/saxon/xdm/empty_sequence.rb
@@ -5,30 +5,43 @@ module Saxon
   module XDM
     # Represents the empty sequence in XDM
     class EmptySequence
+      # Returns an instance. Effectively a Singleton because the EmptySequence
+      # is immutable, and empty. An instance is completely interchangeable with
+      # another. The instance is cached, but multiple instances may exist across
+      # threads. We don't prevent that because it's immaterial.
+      # @return [EmptySequence] The empty sequence
       def self.create
         @instance ||= new
       end
 
       include SequenceLike
 
+      # @return [Enumerator] an enumerator over an empty Array
       def sequence_enum
         [].to_enum
       end
 
+      # @return [Integer] the size of the sequence (always 0)
       def sequence_size
         0
       end
 
+      # All instances of {EmptySequence} are equal to each other.
+      #
+      # @param other [Object] the object to compare self against
+      # @return [Boolean] Whether this object is equal to the other
       def ==(other)
         other.class == self.class
       end
 
       alias_method :eql?, :==
 
+      # @return [Integer] the hash code. All instances have the same hash code.
       def hash
         [].hash
       end
 
+      # @return [net.sf.saxon.s9api.XDMEmptySequence] the underlying Java empty sequence
       def to_java
         @s9_xdm_empty_sequence ||= Saxon::S9API::XdmEmptySequence.getInstance
       end

--- a/lib/saxon/xslt/compiler.rb
+++ b/lib/saxon/xslt/compiler.rb
@@ -42,6 +42,7 @@ module Saxon
       #   Saxon::XDM::AtomicValue>] parameters required at compile time as QName => value hash
 
       # @param source [Saxon::Source] the Source to compile
+      # @yield the block is executed in the context of an {XSLT::EvaluationContext} DSL instance
       # @return [Saxon::XSLT::Executable] the executable stylesheet
       def compile(source, &block)
         Saxon::XSLT::Executable.new(

--- a/lib/saxon/xslt/evaluation_context.rb
+++ b/lib/saxon/xslt/evaluation_context.rb
@@ -48,10 +48,10 @@ module Saxon
       end
 
       # Provides the hooks for constructing a {EvaluationContext} with a DSL.
-      # @api private
       class DSL
         include Common
 
+        # @api private
         # Create an instance based on the args hash, and execute the passed in Proc/lambda against it using <tt>#instance_exec</tt> and return a
         # new {EvaluationContext} with the results
         # @param block [Proc] a Proc/lambda (or <tt>to_proc</tt>'d containing DSL calls
@@ -147,14 +147,16 @@ module Saxon
       end
     end
 
+    # Error raised when a global and static parameter of the same name are
+    # declared
     class GlobalAndStaticParameterClashError < StandardError
     end
 
     module ParameterHelper
       def self.process_parameters(parameters)
-        Hash[parameters.map { |qname, value|
+        parameters.map { |qname, value|
           [Saxon::QName.resolve(qname), Saxon::XDM.Value(value)]
-        }]
+        }.to_h
       end
 
       def self.to_java(parameters)

--- a/spec/saxon/nokogiri_spec.rb
+++ b/spec/saxon/nokogiri_spec.rb
@@ -1,0 +1,30 @@
+require 'saxon/processor'
+require 'saxon/nokogiri'
+
+module Saxon
+  RSpec.describe XSLT do
+    describe "XSLT 1 Nokogiri/saxon-xslt compatible stylesheet processing invocation" do
+      let(:processor) { Saxon::Processor.create }
+      let(:xslt_source) { Saxon::Source.create(fixture_path('eg.xsl')) }
+      let(:xml_source) { Saxon::Source.create('<input/>') }
+      let(:doc) { processor.document_builder.build(xml_source) }
+      let(:xslt) { processor.xslt_compiler.compile(xslt_source) }
+
+      specify "Calling #transform passes param args through correctly to #apply_templates" do
+        expect(xslt).to receive(:apply_templates).with(doc, global_parameters: {
+          Saxon::QName.clark('param') => Saxon::XDM.Value('1')
+        }).and_call_original
+
+        xslt.transform(doc, ['param', '1'])
+      end
+
+      specify "Calling #apply_to serializes the result of calling #transform" do
+        expect(xslt.apply_to(doc, ['testparam', 'testval'])).to eq('<output>testval</output>')
+      end
+
+      specify "Calling #serialize serializes an XML node according to the xsl:output rules in the stylesheet" do
+        expect(xslt.serialize(doc)).to eq('<input/>')
+      end
+    end
+  end
+end

--- a/spec/saxon/processor_spec.rb
+++ b/spec/saxon/processor_spec.rb
@@ -80,6 +80,12 @@ RSpec.describe Saxon::Processor do
           expect(subject.XML(source)).to be_a(Saxon::XDM::Node)
         end
       end
+
+      context "compiling an XSLT stylesheet" do
+        specify "without constructing a Source or Compiler manually" do
+          expect(subject.XSLT(fixture_path('eg.xsl'))).to be_a(Saxon::XSLT::Executable)
+        end
+      end
     end
   end
 end

--- a/spec/saxon/processor_spec.rb
+++ b/spec/saxon/processor_spec.rb
@@ -68,5 +68,18 @@ RSpec.describe Saxon::Processor do
         }.to_not raise_error
       end
     end
+
+    context "Convenience functions" do
+      context "parsing an XML document" do
+        specify "without constructing a DocumentBuilder or Source manually" do
+          expect(subject.XML("<doc/>", encoding: 'UTF-8', base_uri: 'http://example.org/')).to be_a(Saxon::XDM::Node)
+        end
+
+        specify "from a Source without constructing a DocumentBuilder manually" do
+          source = Saxon::Source.create('<doc/>', base_uri: 'http://example.org/')
+          expect(subject.XML(source)).to be_a(Saxon::XDM::Node)
+        end
+      end
+    end
   end
 end

--- a/spec/saxon/source_spec.rb
+++ b/spec/saxon/source_spec.rb
@@ -5,37 +5,43 @@ require 'open-uri'
 RSpec.describe Saxon::Source do
   context "instantiating" do
     context "from IO and IO-like objects" do
-      it "an IO-like with a path" do
+      specify "an IO-like with a path" do
         source = Saxon::Source.from_io(File.open(fixture_path('eg.xml')))
 
         expect(source.base_uri).to eq(fixture_path('eg.xml'))
       end
 
-      it "an open-uri'd file URI" do
+      specify "an open-uri'd file URI" do
         uri = "file://#{fixture_path('eg.xml')}"
         source = Saxon::Source.from_io(open(uri))
 
         expect(source.base_uri).to eq(uri)
       end
 
-      it "an open-uri'd http URI", :vcr do
+      specify "an open-uri'd http URI", :vcr do
         uri = "http://example.org/"
         source = Saxon::Source.from_io(open(uri))
 
         expect(source.base_uri).to eq(uri)
       end
 
-      it "an IO-like, without a base URI" do
+      specify "an IO-like, without a base URI" do
         input = StringIO.new("<doc/>")
         source = Saxon::Source.from_io(input)
 
         expect(source.base_uri).to be_nil
       end
 
-      it "an IO-like, with an explicitly-set base URI, the inherent base URI is overridden" do
+      specify "an IO-like, with an explicitly-set base URI, the inherent base URI is overridden" do
         source = Saxon::Source.from_io(File.open(fixture_path('eg.xml')), base_uri: '/path/elsewhere')
 
         expect(source.base_uri).to eq('/path/elsewhere')
+      end
+
+      specify "an IO, with an explicit Encoding" do
+        source = Saxon::Source.from_io(File.open(fixture_path('eg.xml')), encoding: 'ISO-8859-1')
+
+        expect(source.to_java).to be_a(Saxon::JAXP::StreamSource)
       end
     end
 
@@ -51,6 +57,12 @@ RSpec.describe Saxon::Source do
 
         expect(source.base_uri).to eq('/path/elsewhere')
       end
+
+      it "allows an explicit Encoding" do
+        source = Saxon::Source.from_path(fixture_path('eg.xml'), encoding: 'ISO-8859-1')
+
+        expect(source.to_java).to be_a(Saxon::JAXP::StreamSource)
+      end
     end
 
     context "from a URI" do
@@ -64,6 +76,12 @@ RSpec.describe Saxon::Source do
         source = Saxon::Source.from_uri('http://example.org/', base_uri: 'http://example.org/other')
 
         expect(source.base_uri).to eq('http://example.org/other')
+      end
+
+      it "allows an explicit Encoding", :vcr do
+        source = Saxon::Source.from_uri('http://example.org/', encoding: 'ISO-8859-1')
+
+        expect(source.to_java).to be_a(Saxon::JAXP::StreamSource)
       end
     end
 

--- a/spec/saxon_spec.rb
+++ b/spec/saxon_spec.rb
@@ -5,5 +5,9 @@ RSpec.describe Saxon do
     specify "An XML document can be parsed into a Document node" do
       expect(Saxon::XML('<doc/>')).to be_a(Saxon::XDM::Node)
     end
+
+    specify "An XSLT stylesheet can be parsed into an XSLT::Executable" do
+      expect(Saxon::XSLT(fixture_path('eg.xsl'))).to be_a(Saxon::XSLT::Executable)
+    end
   end
 end

--- a/spec/saxon_spec.rb
+++ b/spec/saxon_spec.rb
@@ -1,0 +1,9 @@
+require 'saxon'
+
+RSpec.describe Saxon do
+  describe "convenience methods" do
+    specify "An XML document can be parsed into a Document node" do
+      expect(Saxon::XML('<doc/>')).to be_a(Saxon::XDM::Node)
+    end
+  end
+end


### PR DESCRIPTION
Add the `Saxon.XML()` and `Saxon.XSLT()` convenience functions that *nokogiri* and *Saxon-XSLT* have. 

Add the Nokogiri / Saxon-XSLT XSLT invocation / serialisation API (roughly) as a require-able extra for people moving from Nokogiri or Saxon-XSLT. (It's such a poor fit for XSLT 2/3 invocation that I'm making it explicitly opt-in and not default.)

Much README love.