### PR TITLE
Add naive serialization for XDM::Node via to_s

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+-e docs/templates/plugin.rb

--- a/docs/templates/plugin.rb
+++ b/docs/templates/plugin.rb
@@ -1,0 +1,73 @@
+include YARD
+include Templates
+
+module JavadocHtmlHelper
+  JAVA_TYPE_MATCHER = /\A(?:[a-z_$](?:[a-z0-9_$]*)\.)+[A-Z][A-Za-z_$]*/
+  RUBY_COLLECTION_TYPE_MATCHER = /\A(?:[A-Z][A-Za-z0-9_])(?:::[A-Z][A-Za-z0-9_]*)*</
+  SAXON_TYPE_MATCHER = /\A(?:net\.sf\.saxon|com\.saxonica)/
+
+  def format_types(typelist, brackets = true)
+    return unless typelist.is_a?(Array)
+    list = typelist.map { |type|
+      case type
+      when JAVA_TYPE_MATCHER
+        format_java_type(type)
+      else
+        super([type], false)
+      end
+    }
+    list.empty? ? "" : (brackets ? "(#{list.join(", ")})" : list.join(", "))
+  end
+
+  def format_java_type(type)
+    "<tt>" + linkify_saxon_type(type) + "</tt>"
+  end
+
+  def linkify_saxon_type(type)
+    case type
+    when SAXON_TYPE_MATCHER
+      link = url_for_java_object(type)
+    else
+      link = nil
+    end
+    link ? link_url(link, type, :title => h(type)) : type
+  end
+
+  def linkify(*args)
+    if args.first.is_a?(String)
+      case args.first
+      when JAVA_TYPE_MATCHER
+        link = url_for_java_object(args.first)
+        title = args.first
+        link ? link_url(link, title, :title => h(title)) : title
+      else
+        super
+      end
+    else
+      super
+    end
+  end
+
+  def url_for(obj, anchor = nil, relative = true)
+    case obj
+    when JAVA_TYPE_MATCHER
+      url_for_java_object(obj, anchor, relative)
+    else
+      super
+    end
+  end
+
+  def url_for_java_object(obj, anchor = nil, relative = nil)
+    case obj
+    when SAXON_TYPE_MATCHER
+      package, _, klass = obj.rpartition(".")
+      "http://saxonica.com/documentation/index.html#!javadoc/#{package}/#{klass}"
+    else
+      path = obj.split(".").join("/")
+      "https://docs.oracle.com/javase/8/docs/api/index.html?#{path}.html"
+    end
+  end
+end
+
+Template.extra_includes << proc { |opts| JavadocHtmlHelper if opts.format == :html }
+# Engine.register_template_path(File.dirname(__FILE__))

--- a/lib/saxon/configuration.rb
+++ b/lib/saxon/configuration.rb
@@ -2,12 +2,13 @@ require 'saxon/s9api'
 require 'saxon/parse_options'
 
 module Saxon
-  # Wraps the <tt>net.saxon.Configuration</tt> class. See
-  # http://saxonica.com/documentation9.5/javadoc/net/sf/saxon/Configuration.html
-  # for details of what configuration options are available and what values
-  # they accept. See
-  # http://saxonica.com/documentation9.5/javadoc/net/sf/saxon/lib/FeatureKeys.html
-  # for details of the constant names used to access the values
+  # Wraps the <tt>net.sf.saxon.Configuration</tt> class.
+  #
+  # See {net.sf.saxon.Configuration} for details of what configuration options
+  # are available and what values they accept.
+  #
+  # See {net.sf.saxon.lib.FeatureKeys} for details of the constant names used to
+  # access the values
   class Configuration
     DEFAULT_SEMAPHORE = Mutex.new
     private_constant :DEFAULT_SEMAPHORE
@@ -60,22 +61,23 @@ module Saxon
     end
 
     # Get a configuration option value
-    # See https://www.saxonica.com/html/documentation/javadoc/net/sf/saxon/lib/FeatureKeys.html
-    # for details of the available options. Use the constant name as a string
-    # or symbol as the option
+    #
+    # See {net.sf.saxon.lib.FeatureKeys} for details of the available options.
+    # Use the constant name as a string or symbol as the option, e.g.
+    # +:allow_multhreading+, +'ALLOW_MULTITHREADING'+, +'allow_multithreading'+.
     #
     # @param option [String, Symbol]
     # @return [Object] the value of the configuration option
     # @raise [NameError] if the option name does not exist
+    # @see net.sf.saxon.lib.FeatureKeys
     def [](option)
       @config.getConfigurationProperty(option_url(option))
     end
 
-    # Get a configuration option value
-    # See http://saxonica.com/documentation9.5/javadoc/net/sf/saxon/lib/FeatureKeys.html
-    # for details of the available options. Use the constant name as a string
-    # or symbol as the option
+    # Set a configuration option value. See {#[]} for details about the option
+    # names.
     #
+    # @see #[]
     # @param option [String, Symbol]
     # @param value [Object] the value of the configuration option
     # @return [Object] the value you passed in

--- a/lib/saxon/feature_flags.rb
+++ b/lib/saxon/feature_flags.rb
@@ -1,0 +1,2 @@
+require_relative 'feature_flags/version'
+require_relative 'feature_flags/helpers'

--- a/lib/saxon/feature_flags.rb
+++ b/lib/saxon/feature_flags.rb
@@ -1,2 +1,11 @@
 require_relative 'feature_flags/version'
 require_relative 'feature_flags/helpers'
+
+module Saxon
+  # Allows saxon-rb features to be switched off if they can't be used under one
+  # of the otherwise-supported Saxon versions
+  #
+  # @api private
+  module FeatureFlags
+  end
+end

--- a/lib/saxon/feature_flags/errors.rb
+++ b/lib/saxon/feature_flags/errors.rb
@@ -1,5 +1,7 @@
 module Saxon
   module FeatureFlags
+    # Error raised if a feature is not available under the loaded version of
+    # Saxon
     class UnavailableInThisSaxonVersionError < StandardError
     end
   end

--- a/lib/saxon/feature_flags/errors.rb
+++ b/lib/saxon/feature_flags/errors.rb
@@ -1,0 +1,6 @@
+module Saxon
+  module FeatureFlags
+    class UnavailableInThisSaxonVersionError < StandardError
+    end
+  end
+end

--- a/lib/saxon/feature_flags/helpers.rb
+++ b/lib/saxon/feature_flags/helpers.rb
@@ -1,6 +1,12 @@
 module Saxon
   module FeatureFlags
+    # Helper methods to create feature restrictions in the library. To be mixed
+    # in to library classes.
     module Helpers
+      # specify that the method named can only run if the version constraint is satisfied
+      #
+      # @param method_name [Symbol] the name of the method
+      # @param version_constraint [String] the version constraint (<tt>'>= 9.9'</tt>)
       def requires_saxon_version(method_name, version_constraint)
         Saxon::FeatureFlags::Version.create(self, method_name, version_constraint)
       end

--- a/lib/saxon/feature_flags/helpers.rb
+++ b/lib/saxon/feature_flags/helpers.rb
@@ -1,0 +1,9 @@
+module Saxon
+  module FeatureFlags
+    module Helpers
+      def requires_saxon_version(method_name, version_constraint)
+        Saxon::FeatureFlags::Version.create(self, method_name, version_constraint)
+      end
+    end
+  end
+end

--- a/lib/saxon/feature_flags/version.rb
+++ b/lib/saxon/feature_flags/version.rb
@@ -12,17 +12,18 @@ module Saxon
         method = klass.instance_method(method_name)
         version_check = new(version_constraint)
 
-        klass.define_method(method_name) do |*args|
+
+        klass.send(:define_method, method_name, ->(*args) {
           if version_check.ok?
-            klass.define_method(method_name, method)
+            klass.send(:define_method, method_name, method)
             method.bind(self).call(*args)
           else
-            klass.define_method(method_name) do |*args|
+            klass.send(:define_method, method_name, ->(*args) {
               raise UnavailableInThisSaxonVersionError
-            end
+            })
             raise UnavailableInThisSaxonVersionError
           end
-        end
+        })
       end
 
       attr_reader :constraint_string, :comparison_operator, :version_string

--- a/lib/saxon/feature_flags/version.rb
+++ b/lib/saxon/feature_flags/version.rb
@@ -1,0 +1,65 @@
+require_relative '../version/library'
+require_relative 'errors'
+
+module Saxon
+  # Allows saxon-rb features to be switched off if they can't be used under one
+  # of the otherwise-supported Saxon versions
+  #
+  # @api private
+  module FeatureFlags
+    class Version
+      def self.create(klass, method_name, version_constraint)
+        method = klass.instance_method(method_name)
+        version_check = new(version_constraint)
+
+        klass.define_method(method_name) do |*args|
+          if version_check.ok?
+            klass.define_method(method_name, method)
+            method.bind(self).call(*args)
+          else
+            klass.define_method(method_name) do |*args|
+              raise UnavailableInThisSaxonVersionError
+            end
+            raise UnavailableInThisSaxonVersionError
+          end
+        end
+      end
+
+      attr_reader :constraint_string, :comparison_operator, :version_string
+
+      def initialize(constraint_string)
+        @constraint_string = constraint_string
+        @comparison_operator, @version_string = parse_version_constraint(constraint_string)
+      end
+
+      def ok?
+        Saxon::Version::Library.loaded_version.send(comparison_operator, constraint_version)
+      end
+
+      def constraint_version
+        @constraint_version ||= begin
+          components = version_string.split('.').map { |n| Integer(n, 10) }
+          Saxon::Version::Library.new(version_string, components, 'HE')
+        end
+      end
+
+      private
+
+      def parse_version_constraint(version_constraint)
+        op_string, version_string = version_constraint.split
+
+        comparison_operator = parse_operator_string(op_string)
+        [comparison_operator, version_string]
+      end
+
+      def parse_operator_string(op_string)
+        case op_string
+        when '~>'
+          :pessimistic_compare
+        else
+          op_string.to_sym
+        end
+      end
+    end
+  end
+end

--- a/lib/saxon/feature_flags/version.rb
+++ b/lib/saxon/feature_flags/version.rb
@@ -2,12 +2,31 @@ require_relative '../version/library'
 require_relative 'errors'
 
 module Saxon
-  # Allows saxon-rb features to be switched off if they can't be used under one
-  # of the otherwise-supported Saxon versions
-  #
-  # @api private
   module FeatureFlags
+    # Restrict a specific method to only work with the specified Saxon version
     class Version
+      # Modify the method so that it will only run if the version constraint is
+      # satisfied.
+      #
+      # We can't know what version of Saxon is in use at code load time, only
+      # once {Saxon::Loader#load!} has been called, either explicitly or by
+      # calling a method which requires a Saxon Java object. Therefore, we have
+      # to check this the first time someone calls the method.
+      #
+      # Creating this check replaces the method on the target class with one
+      # that checks the version, and runs the original version if its constraint
+      # is satisfied.
+      #
+      # To avoid performing the check every time the method is called, once we
+      # know whether or not the constraint is satisfied, we assume that the
+      # verion of Saxon cannot be unloaded and a new one loaded in its place and
+      # replace our version checking method with the original (if the constraint
+      # is passed), or with one that simply +raise+s the constraint error.
+      #
+      # @param klass [Class] the class the method lives on
+      # @param method_name [Symbol] the name of the method to be constrained
+      # @param version_constraint [String] the version constraint
+      #   (<tt>'>9.9.1.7'</tt> or <tt>'>= 9.9'</tt>)
       def self.create(klass, method_name, version_constraint)
         method = klass.instance_method(method_name)
         version_check = new(version_constraint)
@@ -26,17 +45,32 @@ module Saxon
         })
       end
 
-      attr_reader :constraint_string, :comparison_operator, :version_string
+      # @return [String] the complete constraint string
+      attr_reader :constraint_string
+      # @return [Symbol] the extracted comparison operator
+      attr_reader :comparison_operator
+      # @return [String] the extracted version string
+      attr_reader :version_string
 
+      # Create a version constraint check from the supplied constraint string
+      #
+      # @param constraint_string [String] the version constraint
       def initialize(constraint_string)
         @constraint_string = constraint_string
         @comparison_operator, @version_string = parse_version_constraint(constraint_string)
       end
 
+      # Reports if the version constraint is satisfied or not.
+      #
+      # @return [Boolean] true if the constraint is satisfied, false otherwise
       def ok?
         Saxon::Version::Library.loaded_version.send(comparison_operator, constraint_version)
       end
 
+      # Generates a {Saxon::Version::Library} representing the version specified
+      # in the constraint that can be compared with the loaded Saxon version
+      #
+      # @return [Saxon::Version::Library] the constraint version
       def constraint_version
         @constraint_version ||= begin
           components = version_string.split('.').map { |n| Integer(n, 10) }

--- a/lib/saxon/version.rb
+++ b/lib/saxon/version.rb
@@ -4,6 +4,6 @@ module Saxon
   # Provides the saxon-rb and underlying Saxon library versions
   module Version
     # The version of the saxon-rb gem (not of Saxon itself)
-    WRAPPER = "0.6.0"
+    WRAPPER = "0.7.0"
   end
 end

--- a/lib/saxon/version.rb
+++ b/lib/saxon/version.rb
@@ -1,4 +1,9 @@
+require 'saxon/s9api'
+
 module Saxon
-  # The version of the saxon-rb gem
-  VERSION = "0.6.0"
+  # Provides the saxon-rb and underlying Saxon library versions
+  module Version
+    # The version of the saxon-rb gem (not of Saxon itself)
+    WRAPPER = "0.6.0"
+  end
 end

--- a/lib/saxon/version/library.rb
+++ b/lib/saxon/version/library.rb
@@ -1,0 +1,72 @@
+require 'saxon/s9api'
+
+module Saxon
+  module Version
+    # The version of the underlying Saxon library, which we need to discover at
+    # runtime based on what version is on the Classpath
+    class Library
+      def self.loaded_version
+        Saxon::Loader.load!
+
+        sv = Java::net.sf.saxon.Version
+        new(sv.getProductVersion, sv.getStructuredVersionNumber, sv.softwareEdition)
+      end
+
+      include Comparable
+
+      # @return [String] the version string (e.g. '9.9.1.6', '10.0')
+      attr_reader :version
+      # @return [String] the version components (e.g. <tt>[9, 9, 1, 6]</tt>, <tt>[10, 0]</tt>)
+      attr_reader :components
+      # @return [Symbol] the edition (+:he+, +:pe+, or +:ee+)
+      attr_reader :edition
+
+      def initialize(version, components, edition)
+        @version = version.dup.freeze
+        @components = components.dup.freeze
+        @edition = edition.downcase.to_sym
+      end
+
+      def <=>(other)
+        return false unless other.is_a?(self.class)
+
+        n_components = [self.components.length, other.components.length].max
+        (0..(n_components - 1)).reduce(0, &comparator(other))
+      end
+
+      def pessimistic_compare(pessimistic_version)
+        pessimistic_components = pessimistic_version.components
+        pessimistic_components = pessimistic_components + [0] if pessimistic_components.length == 1
+        locked = pessimistic_components[0..-2]
+        locked = locked.zip(components[0..locked.length])
+        variable = [pessimistic_components[-1], components[locked.length]]
+
+        locked_ok = locked.all? { |check, mine|
+          check == mine
+        }
+
+        return false unless locked_ok
+
+        check, mine = variable
+        mine >= check
+      end
+
+      def to_s
+        version
+      end
+
+      private
+
+      def comparator(other)
+        ->(cmp, i) {
+          return cmp unless cmp == 0
+
+          mine = self.components[i].nil? ? 0 : self.components[i]
+          theirs = other.components[i].nil? ? 0 : other.components[i]
+
+          mine <=> theirs
+        }
+      end
+    end
+  end
+end

--- a/lib/saxon/version/library.rb
+++ b/lib/saxon/version/library.rb
@@ -5,6 +5,9 @@ module Saxon
     # The version of the underlying Saxon library, which we need to discover at
     # runtime based on what version is on the Classpath
     class Library
+      # The loaded version of the Saxon Java library
+      #
+      # @return [Saxon::Version::Library] the version of the loaded library
       def self.loaded_version
         Saxon::Loader.load!
 
@@ -21,12 +24,19 @@ module Saxon
       # @return [Symbol] the edition (+:he+, +:pe+, or +:ee+)
       attr_reader :edition
 
+      # @param version [String] the version string
+      # @param components [Array<Integer>] the version components separated
+      # @param edition [String, Symbol] the name of the Saxon edition (e.g. +:he+, +'HE'+)
       def initialize(version, components, edition)
         @version = version.dup.freeze
         @components = components.dup.freeze
         @edition = edition.downcase.to_sym
       end
 
+      # Comparison against another instance
+      #
+      # @param other [Saxon::Version::Library] the other version to compare against
+      # @return [Integer] -1 for less, 1 for greater, 0 for equal
       def <=>(other)
         return false unless other.is_a?(self.class)
 
@@ -34,6 +44,12 @@ module Saxon
         (0..(n_components - 1)).reduce(0, &comparator(other))
       end
 
+      # Pessimistic comparison à la rubygems +~>+: do I satisfy the other
+      # version if considered as a pessimistic version constraint
+      #
+      # @param pessimistic_version [Saxon::Version::Library] the version to
+      #   compare pessimistically
+      # @return [Boolean] do I satisfy the constraint?
       def pessimistic_compare(pessimistic_version)
         pessimistic_components = pessimistic_version.components
         pessimistic_components = pessimistic_components + [0] if pessimistic_components.length == 1
@@ -51,6 +67,7 @@ module Saxon
         mine >= check
       end
 
+      # @return [String] the version string
       def to_s
         version
       end

--- a/lib/saxon/xdm/node.rb
+++ b/lib/saxon/xdm/node.rb
@@ -85,6 +85,36 @@ module Saxon
       def axis_iterator(axis)
         AxisIterator.new(self, axis)
       end
+
+      # Use Saxon's naive XDM Node serialisation to serialize the node and its
+      # descendants. Saxon uses a new Serializer with default options to
+      # serialize the node. In particular, if the Node was produced by an XSLT
+      # that used +<xsl:character-map>+ through +<xsl:output>+ to modify the
+      # contents, then they *WILL* *NOT* have been applied.
+      #
+      # +<xsl:output>+ has its effect at serialization time, not at XDM tree
+      # creation time, so it won't be applied until you serialize the document.
+      #
+      # Even then, unless you use a {Serializer} configured with the XSLT's
+      # +<xsl:output>+. We make a properly configured serializer available in
+      # the result of any XSLT transform (a {Saxon::XSLT::Invocation}), e.g.:
+      #
+      #   result = xslt.apply_templates(input)
+      #   result.to_s
+      #   # or
+      #   result.serialize('/path/to/output.xml')
+      #
+      # You can also get that {Serializer} directly from {XSLT::Executable},
+      # should you want to use the serialization options from a particular XSLT
+      # to serialize arbitrary XDM values:
+      #
+      #   serializer = xslt.serializer
+      #   serializer.serialize(an_xdm_value)
+      #
+      # @see http://www.saxonica.com/documentation9.9/index.html#!javadoc/net.sf.saxon.s9api/XdmNode@toString
+      def to_s
+        s9_xdm_node.toString
+      end
     end
   end
 end

--- a/lib/saxon/xslt/executable.rb
+++ b/lib/saxon/xslt/executable.rb
@@ -162,6 +162,14 @@ module Saxon
         transformation(opts.reject { |k, v| k == :args }).call_function(function_name, args)
       end
 
+      # Create a {Serializer::Object} configured using the options that were set
+      # by +<xsl:output>+.
+      #
+      # @return [Saxon::Serializer::Object] the Serializer
+      def serializer
+        Saxon::Serializer::Object.new(@s9_xslt_executable.load30.newSerializer)
+      end
+
       # @return [net.sf.saxon.s9api.XsltExecutable] the underlying Saxon
       #   +XsltExecutable+
       def to_java

--- a/lib/saxon/xslt/executable.rb
+++ b/lib/saxon/xslt/executable.rb
@@ -4,6 +4,7 @@ require_relative 'invocation'
 require_relative '../serializer'
 require_relative '../xdm'
 require_relative '../qname'
+require_relative '../feature_flags'
 
 module Saxon
   module XSLT
@@ -53,6 +54,7 @@ module Saxon
     # prefix, you must use an explicit {Saxon::QName} to refer to it.
     class Executable
       extend Forwardable
+      extend Saxon::FeatureFlags::Helpers
 
       attr_reader :evaluation_context
       private :evaluation_context
@@ -169,6 +171,7 @@ module Saxon
       def serializer
         Saxon::Serializer::Object.new(@s9_xslt_executable.load30.newSerializer)
       end
+      requires_saxon_version :serializer, '>= 9.9'
 
       # @return [net.sf.saxon.s9api.XsltExecutable] the underlying Saxon
       #   +XsltExecutable+

--- a/saxon-rb.gemspec
+++ b/saxon-rb.gemspec
@@ -5,7 +5,7 @@ require 'saxon/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'saxon-rb'
-  spec.version       = Saxon::VERSION
+  spec.version       = Saxon::Version::WRAPPER
   spec.authors       = ['Matt Patterson']
   spec.email         = ['matt@werkstatt.io']
 

--- a/spec/fixtures/serialization.xsl
+++ b/spec/fixtures/serialization.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
-    <xsl:output method="text" indent="no" omit-xml-declaration="yes" use-character-maps="silly"/>
+    <xsl:output indent="no" omit-xml-declaration="yes" use-character-maps="silly"/>
     <xsl:character-map name="silly">
         <xsl:output-character character="a" string="b"/>
     </xsl:character-map>

--- a/spec/fixtures/serialization.xsl
+++ b/spec/fixtures/serialization.xsl
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:output method="text" indent="no" omit-xml-declaration="yes" use-character-maps="silly"/>
+    <xsl:character-map name="silly">
+        <xsl:output-character character="a" string="b"/>
+    </xsl:character-map>
+</xsl:stylesheet>

--- a/spec/saxon/feature_flags/version_spec.rb
+++ b/spec/saxon/feature_flags/version_spec.rb
@@ -1,0 +1,53 @@
+require 'saxon/version/library'
+require 'saxon/feature_flags'
+
+module Saxon
+  RSpec.describe FeatureFlags::Version do
+    describe "methods only exposed in certain versions" do
+      def test_class(target_version)
+        Class.new {
+          extend Saxon::FeatureFlags::Helpers
+
+          def test_method
+            :result
+          end
+          requires_saxon_version :test_method, "> #{target_version}"
+        }
+      end
+
+      specify "raises UnavailableInThisSaxonVersionError if it's called" do
+        klass = test_class(Saxon::Version::Library.loaded_version)
+
+        expect { klass.new.test_method }.to raise_error(Saxon::FeatureFlags::UnavailableInThisSaxonVersionError)
+      end
+
+      specify "executes normally if the version is okay" do
+        klass = test_class(Saxon::Version::Library.loaded_version.components[0] - 1)
+
+        expect(klass.new.test_method).to eq(:result)
+      end
+
+      context "rebound method caching" do
+        specify "works for passing checks" do
+          klass = test_class(Saxon::Version::Library.loaded_version.components[0] - 1)
+
+          instance = klass.new
+          expect(klass.new.test_method).to eq(:result)
+          expect(instance.test_method).to eq(:result)
+          expect(instance.test_method).to eq(:result)
+        end
+
+        specify "works for failing checks" do
+          klass = test_class(Saxon::Version::Library.loaded_version)
+
+          instance = klass.new
+          expect { klass.new.test_method }.to raise_error(Saxon::FeatureFlags::UnavailableInThisSaxonVersionError)
+          expect { instance.test_method }.to raise_error(Saxon::FeatureFlags::UnavailableInThisSaxonVersionError)
+          expect { instance.test_method }.to raise_error(Saxon::FeatureFlags::UnavailableInThisSaxonVersionError)
+        end
+      end
+    end
+
+    describe "classes only defined in certain versions"
+  end
+end

--- a/spec/saxon/version/library_spec.rb
+++ b/spec/saxon/version/library_spec.rb
@@ -1,0 +1,170 @@
+require 'saxon/version/library'
+
+module Saxon
+  RSpec.describe Version::Library do
+    context "the currently loaded version" do
+      subject { described_class.loaded_version }
+
+      specify "returns the correct version string" do
+        expect(subject.version).to eq(Java::net.sf.saxon.Version.getProductVersion)
+      end
+
+      specify "returns the correct edition" do
+        expect(subject.edition).to eq(:he)
+      end
+
+      specify "returns the correct version components" do
+        expect(subject.components).to eq(subject.version.split('.').map { |n| Integer(n, 10) })
+      end
+
+      specify "returns the string version for #to_s" do
+        expect(subject.to_s).to eq(subject.version.to_s)
+      end
+    end
+
+    context "another version" do
+      subject { described_class.new("10.0", [10, 0], "EE") }
+
+      specify "returns the correct version string" do
+        expect(subject.version).to eq("10.0")
+      end
+
+      specify "returns the correct edition" do
+        expect(subject.edition).to eq(:ee)
+      end
+
+      specify "returns the correct version components" do
+        expect(subject.components).to eq([10, 0])
+      end
+    end
+
+    describe "comparing versions" do
+      let(:v9_9_1_7) { described_class.new("9.9.1.7", [9, 9, 1, 7], "HE") }
+      let(:v9_10_0_0) { described_class.new("9.10.0.0", [9, 10, 0, 0], "HE") }
+      let(:v9_9_1_6) { described_class.new("9.9.1.6", [9, 9, 1, 6], "HE") }
+      let(:v10_0) { described_class.new("10.0", [10, 0], "HE") }
+
+      context "greater-than" do
+        specify "10.0 > 9.9" do
+          expect(v10_0 > v9_9_1_7).to be(true)
+        end
+
+        specify "9.10.0.0 > 9.9.1.7" do
+          expect(v9_10_0_0 > v9_9_1_7).to be(true)
+        end
+      end
+
+      context "less-than" do
+        specify "9.9.1.6 < 9.9.1.7" do
+          expect(v9_9_1_6 < v9_9_1_7).to be(true)
+        end
+      end
+
+      context "greater-than-or-equal-to" do
+        specify "9.9.1.7 >= 9.9.1.7" do
+          expect(v9_9_1_7 >= v9_9_1_7).to be(true)
+        end
+
+        specify "10.0 >= 9.9.1.7" do
+          expect(v10_0 >= v9_9_1_7).to be(true)
+        end
+      end
+
+      context "less-than-or-equal-to" do
+        specify "9.9.1.7 <= 9.9.1.7" do
+          expect(v9_9_1_7 <= v9_9_1_7).to be(true)
+        end
+
+        specify "9.9.1.7 <= 10" do
+          expect(v9_9_1_7 <= v10_0).to be(true)
+        end
+      end
+
+      context "equal" do
+        specify "9.9.1.7 == 9.9.1.7" do
+          expect(v9_9_1_7 == v9_9_1_7).to be(true)
+        end
+
+        specify "9.9.1.6 != 9.9.1.7" do
+          expect(v9_9_1_6 != v9_9_1_7).to be(true)
+        end
+      end
+
+      context "~> pessimistic version comparison" do
+        let(:v8_9_0_0) { described_class.new("8.9.0.0", [8,9,0,0], "HE") }
+        let(:v9_8_0_0) { described_class.new("9.8.0.0", [9,8,0,0], "HE") }
+        let(:v9_9_0_0) { described_class.new("9.9.0.0", [9,9,0,0], "HE") }
+        let(:v9_9_1_0) { described_class.new("9.9.1.0", [9,9,1,0], "HE") }
+        let(:v9_9_1) { described_class.new("9.9.1", [9,9,1], "HE") }
+        let(:v9_9) { described_class.new("9.9", [9,9], "HE") }
+        let(:v9_0) { described_class.new("9.0", [9,0], "HE") }
+        let(:v9_9_2_0) { described_class.new("9.9.2.0", [9,9,2,0], "HE") }
+
+        context "passes" do
+          specify "9.9.1.6 ~> 9.9.1.0" do
+            expect(v9_9_1_6.pessimistic_compare(v9_9_1_0)).to be(true)
+          end
+
+          specify "9.9.1.6 ~> 9.9.1.6" do
+            expect(v9_9_1_6.pessimistic_compare(v9_9_1_6)).to be(true)
+          end
+
+          specify "9.9.1.6 ~> 9.9.1" do
+            expect(v9_9_1_6.pessimistic_compare(v9_9_1)).to be(true)
+          end
+
+          specify "9.9.2.0 ~> 9.9.1" do
+            expect(v9_9_2_0.pessimistic_compare(v9_9_1)).to be(true)
+          end
+
+          specify "9.9.1.6 ~> 9.9" do
+            expect(v9_9_1_6.pessimistic_compare(v9_9)).to be(true)
+          end
+
+          specify "9.10.0.0 ~> 9.9" do
+            expect(v9_10_0_0.pessimistic_compare(v9_9)).to be(true)
+          end
+
+          specify "9.9.1.6 ~> 9" do
+            expect(v9_9_1_6.pessimistic_compare(v9_0)).to be(true)
+          end
+
+        end
+
+        context "fails" do
+          specify "9.9.2.0 ~> 9.9.1.0" do
+            expect(v9_9_2_0.pessimistic_compare(v9_9_1_0)).to be(false)
+          end
+
+          specify "9.9.1.6 ~> 9.9.1.7" do
+            expect(v9_9_1_6.pessimistic_compare(v9_9_1_7)).to be(false)
+          end
+
+          specify "9.9.0.0 ~> 9.9.1" do
+            expect(v9_9_0_0.pessimistic_compare(v9_9_1)).to be(false)
+          end
+
+          specify "9.10.0.0 ~> 9.9.1" do
+            expect(v9_10_0_0.pessimistic_compare(v9_9_1)).to be(false)
+          end
+
+          specify "9.8 ~> 9.9" do
+            expect(v9_8_0_0.pessimistic_compare(v9_9)).to be(false)
+          end
+
+          specify "10.0 ~> 9.9" do
+            expect(v10_0.pessimistic_compare(v9_9)).to be(false)
+          end
+
+          specify "8.9.0.0 ~> 9" do
+            expect(v8_9_0_0.pessimistic_compare(v9_0)).to be(false)
+          end
+
+          specify "10.0 ~> 9" do
+            expect(v10_0.pessimistic_compare(v9_0)).to be(false)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/saxon/xdm/node_spec.rb
+++ b/spec/saxon/xdm/node_spec.rb
@@ -66,6 +66,12 @@ RSpec.describe Saxon::XDM::Node do
       end
     end
 
+    context "default serialisation with to_s" do
+      specify "uses Saxon's toString naive serialisation" do
+        expect(doc_node.to_s).to eq("<doc/>")
+      end
+    end
+
     it_should_behave_like "an XDM Value hierarchy sequence-like"
     it_should_behave_like "an XDM Item hierarchy sequence-like"
   end

--- a/spec/saxon/xdm/node_spec.rb
+++ b/spec/saxon/xdm/node_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Saxon::XDM::Node do
 
     context "default serialisation with to_s" do
       specify "uses Saxon's toString naive serialisation" do
-        expect(doc_node.to_s).to eq("<doc/>")
+        expect(doc_node.to_s.strip).to eq("<doc/>")
       end
     end
 

--- a/spec/saxon/xslt/executable_spec.rb
+++ b/spec/saxon/xslt/executable_spec.rb
@@ -1,6 +1,7 @@
 require 'saxon/processor'
 require 'saxon/source'
 require 'saxon/qname'
+require 'saxon/xdm/value'
 require 'saxon/xslt/executable'
 
 module Saxon::XSLT
@@ -200,6 +201,19 @@ module Saxon::XSLT
             expect(result.xdm_value).to eq(Saxon::XDM.AtomicValue(1))
           end
         end
+      end
+    end
+
+    describe "a Serializer using the <xsl:output> options" do
+      let(:xsl_source) { fixture_source('serialization.xsl') }
+      let(:compiler) { processor.xslt_compiler }
+
+      subject { compiler.compile(xsl_source) }
+
+      specify "the Serializer was correctly configured" do
+        serializer = subject.serializer
+
+        expect(serializer.serialize(Saxon::XDM.Value('a'))).to eq('b')
       end
     end
   end

--- a/spec/saxon/xslt/executable_spec.rb
+++ b/spec/saxon/xslt/executable_spec.rb
@@ -204,16 +204,18 @@ module Saxon::XSLT
       end
     end
 
-    describe "a Serializer using the <xsl:output> options" do
-      let(:xsl_source) { fixture_source('serialization.xsl') }
-      let(:compiler) { processor.xslt_compiler }
+    requires_saxon('>= 9.9') do
+      describe "a Serializer using the <xsl:output> options" do
+        let(:xsl_source) { fixture_source('serialization.xsl') }
+        let(:compiler) { processor.xslt_compiler }
 
-      subject { compiler.compile(xsl_source) }
+        subject { compiler.compile(xsl_source) }
 
-      specify "the Serializer was correctly configured" do
-        serializer = subject.serializer
+        specify "the Serializer was correctly configured" do
+          serializer = subject.serializer
 
-        expect(serializer.serialize(Saxon::XDM.Value('a'))).to eq('b')
+          expect(serializer.serialize(Saxon::XDM.Value('a'))).to eq('b')
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,16 @@ end
 
 module SaxonEditionHelpers
   def requires_pe(&block)
+
+  end
+
+  def requires_saxon(constraint, &block)
+    require 'saxon/version/library'
+    require 'saxon/feature_flags/version'
+
+    if Saxon::FeatureFlags::Version.new(constraint).ok?
+      class_exec(&block)
+    end
   end
 end
 
@@ -54,6 +64,9 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+
+  config.filter_run_excluding :broken => true
 
   config.include FixtureHelpers
   config.extend SaxonEditionHelpers


### PR DESCRIPTION
This mirrors Saxon's native XdmNode.toString() and the old saxon-xslt
behaviour. The documentation for XDM::Node#to_s calls out the problems
with the naive approach and gives samples of how to serialize XSLT
result nodes in the way you might expect to be the default.

Addresses #10.