### PR TITLE
saxon/item_type.rb lazy-loads saxon jars

### DIFF
--- a/lib/saxon/version.rb
+++ b/lib/saxon/version.rb
@@ -4,6 +4,6 @@ module Saxon
   # Provides the saxon-rb and underlying Saxon library versions
   module Version
     # The version of the saxon-rb gem (not of Saxon itself)
-    WRAPPER = "0.7.1"
+    WRAPPER = "0.7.2"
   end
 end


### PR DESCRIPTION
Stop ItemType eager-loading the saxon jars by only accessing constants
under S9API when someone tries to do something with an ItemType.

Fix #15

This issue needs wider testing (in a separate process, since every other
test needs the saxon jars loaded...) but the problem is urgent enough to
rush out a fix which has been manually tested. No more releases until
the loading stuff is properly tested (in isolation) though.