### PR TITLE
Work around JRuby bug, restoring compatibility across 9.x.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,24 +24,12 @@ jobs:
         name: Bundle Install
         command: bundle check || bundle install
     - run:
-        name: Install Code Climate Test Reporter
-        command: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-          chmod +x ./cc-test-reporter
-    - run:
-        name: Run the tests, and upload coverage data to Code Climate
+        name: Run the tests
         command: |-
-          ./cc-test-reporter before-build
           mkdir -p /tmp/test-results
           VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
-          if [ $? -eq 0 ]; then ./cc-test-reporter format-coverage -t simplecov -o "cc-coverage-jar-loading-alt-saxon.json"; fi
           rm -rf coverage
           bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
-          if [ $? -eq 0 ]; then ./cc-test-reporter format-coverage -t simplecov -o "cc-coverage-main-alt-saxon.json"; fi
-    - persist_to_workspace:
-        root: "~/project"
-        paths:
-        - cc-coverage*
     - store_test_results:
         path: "/tmp/test-results"
     - store_artifacts:
@@ -61,24 +49,12 @@ jobs:
         name: Bundle Install
         command: bundle check || bundle install
     - run:
-        name: Install Code Climate Test Reporter
-        command: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-          chmod +x ./cc-test-reporter
-    - run:
-        name: Run the tests, and upload coverage data to Code Climate
+        name: Run the tests
         command: |-
-          ./cc-test-reporter before-build
           mkdir -p /tmp/test-results
           VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
-          if [ $? -eq 0 ]; then ./cc-test-reporter format-coverage -t simplecov -o "cc-coverage-jar-loading.json"; fi
           rm -rf coverage
           bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
-          if [ $? -eq 0 ]; then ./cc-test-reporter format-coverage -t simplecov -o "cc-coverage-main.json"; fi
-    - persist_to_workspace:
-        root: "~/project"
-        paths:
-        - cc-coverage*
     - store_test_results:
         path: "/tmp/test-results"
     - store_artifacts:
@@ -261,9 +237,9 @@ jobs:
     - store_artifacts:
         path: "/tmp/test-results"
         destination: test-results
-  JRuby 9.2.10.0-SNAPSHOT-latest, JDK 8 Saxon HE 9.8:
+  JRuby 9.2.10.0, JDK 8 Saxon HE 9.8:
     docker:
-    - image: fidothe/circleci:jruby-9.2.10.0-SNAPSHOT-latest-8-jdk-slim
+    - image: fidothe/circleci:jruby-9.2.10.0-8-jdk-slim
     environment:
       BUNDLE_JOBS: 3
       BUNDLE_RETRY: 3
@@ -295,9 +271,9 @@ jobs:
     - store_artifacts:
         path: "/tmp/test-results"
         destination: test-results
-  JRuby 9.2.10.0-SNAPSHOT-latest, JDK 8:
+  JRuby 9.2.10.0, JDK 8:
     docker:
-    - image: fidothe/circleci:jruby-9.2.10.0-SNAPSHOT-latest-8-jdk-slim
+    - image: fidothe/circleci:jruby-9.2.10.0-8-jdk-slim
     environment:
       BUNDLE_JOBS: 3
       BUNDLE_RETRY: 3
@@ -320,68 +296,9 @@ jobs:
     - store_artifacts:
         path: "/tmp/test-results"
         destination: test-results
-  JRuby 9.2.10.0-SNAPSHOT-latest, JDK 11 Saxon HE 9.8:
+  JRuby 9.2.10.0, JDK 11 Saxon HE 9.8:
     docker:
-    - image: fidothe/circleci:jruby-9.2.10.0-SNAPSHOT-latest-11-jdk-slim
-    environment:
-      BUNDLE_JOBS: 3
-      BUNDLE_RETRY: 3
-      BUNDLE_PATH: vendor/bundle
-      JRUBY_OPTS: "--dev --debug"
-      ALTERNATE_SAXON_HOME: "/tmp/saxon"
-    steps:
-    - checkout
-    - run:
-        name: Download SaxonHE9-8-0-15J.zip
-        command: |-
-          mkdir -p /tmp/saxon
-          cd /tmp/saxon
-          curl -L -O https://sourceforge.net/projects/saxon/files/Saxon-HE/9.8/SaxonHE9-8-0-15J.zip
-          unzip SaxonHE9-8-0-15J.zip
-          rm -f SaxonHE9-8-0-15J.zip
-    - run:
-        name: Bundle Install
-        command: bundle check || bundle install
-    - run:
-        name: Run the tests
-        command: |-
-          mkdir -p /tmp/test-results
-          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
-          rm -rf coverage
-          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
-    - store_test_results:
-        path: "/tmp/test-results"
-    - store_artifacts:
-        path: "/tmp/test-results"
-        destination: test-results
-  JRuby 9.2.10.0-SNAPSHOT-latest, JDK 11:
-    docker:
-    - image: fidothe/circleci:jruby-9.2.10.0-SNAPSHOT-latest-11-jdk-slim
-    environment:
-      BUNDLE_JOBS: 3
-      BUNDLE_RETRY: 3
-      BUNDLE_PATH: vendor/bundle
-      JRUBY_OPTS: "--dev --debug"
-    steps:
-    - checkout
-    - run:
-        name: Bundle Install
-        command: bundle check || bundle install
-    - run:
-        name: Run the tests
-        command: |-
-          mkdir -p /tmp/test-results
-          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
-          rm -rf coverage
-          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
-    - store_test_results:
-        path: "/tmp/test-results"
-    - store_artifacts:
-        path: "/tmp/test-results"
-        destination: test-results
-  JRuby 9.2.10.0-SNAPSHOT-latest, JDK 13 Saxon HE 9.8:
-    docker:
-    - image: fidothe/circleci:jruby-9.2.10.0-SNAPSHOT-latest-13-jdk-slim
+    - image: fidothe/circleci:jruby-9.2.10.0-11-jdk-slim
     environment:
       BUNDLE_JOBS: 3
       BUNDLE_RETRY: 3
@@ -413,9 +330,623 @@ jobs:
     - store_artifacts:
         path: "/tmp/test-results"
         destination: test-results
-  JRuby 9.2.10.0-SNAPSHOT-latest, JDK 13:
+  JRuby 9.2.10.0, JDK 11:
     docker:
-    - image: fidothe/circleci:jruby-9.2.10.0-SNAPSHOT-latest-13-jdk-slim
+    - image: fidothe/circleci:jruby-9.2.10.0-11-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+    steps:
+    - checkout
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.10.0, JDK 13 Saxon HE 9.8:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.10.0-13-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+      ALTERNATE_SAXON_HOME: "/tmp/saxon"
+    steps:
+    - checkout
+    - run:
+        name: Download SaxonHE9-8-0-15J.zip
+        command: |-
+          mkdir -p /tmp/saxon
+          cd /tmp/saxon
+          curl -L -O https://sourceforge.net/projects/saxon/files/Saxon-HE/9.8/SaxonHE9-8-0-15J.zip
+          unzip SaxonHE9-8-0-15J.zip
+          rm -f SaxonHE9-8-0-15J.zip
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.10.0, JDK 13:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.10.0-13-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+    steps:
+    - checkout
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.11.1, JDK 8 Saxon HE 9.8:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.11.1-8-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+      ALTERNATE_SAXON_HOME: "/tmp/saxon"
+    steps:
+    - checkout
+    - run:
+        name: Download SaxonHE9-8-0-15J.zip
+        command: |-
+          mkdir -p /tmp/saxon
+          cd /tmp/saxon
+          curl -L -O https://sourceforge.net/projects/saxon/files/Saxon-HE/9.8/SaxonHE9-8-0-15J.zip
+          unzip SaxonHE9-8-0-15J.zip
+          rm -f SaxonHE9-8-0-15J.zip
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.11.1, JDK 8:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.11.1-8-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+    steps:
+    - checkout
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.11.1, JDK 11 Saxon HE 9.8:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.11.1-11-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+      ALTERNATE_SAXON_HOME: "/tmp/saxon"
+    steps:
+    - checkout
+    - run:
+        name: Download SaxonHE9-8-0-15J.zip
+        command: |-
+          mkdir -p /tmp/saxon
+          cd /tmp/saxon
+          curl -L -O https://sourceforge.net/projects/saxon/files/Saxon-HE/9.8/SaxonHE9-8-0-15J.zip
+          unzip SaxonHE9-8-0-15J.zip
+          rm -f SaxonHE9-8-0-15J.zip
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.11.1, JDK 11:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.11.1-11-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+    steps:
+    - checkout
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.11.1, JDK 13 Saxon HE 9.8:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.11.1-13-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+      ALTERNATE_SAXON_HOME: "/tmp/saxon"
+    steps:
+    - checkout
+    - run:
+        name: Download SaxonHE9-8-0-15J.zip
+        command: |-
+          mkdir -p /tmp/saxon
+          cd /tmp/saxon
+          curl -L -O https://sourceforge.net/projects/saxon/files/Saxon-HE/9.8/SaxonHE9-8-0-15J.zip
+          unzip SaxonHE9-8-0-15J.zip
+          rm -f SaxonHE9-8-0-15J.zip
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.11.1, JDK 13:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.11.1-13-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+    steps:
+    - checkout
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.12.0, JDK 8 Saxon HE 9.8:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.12.0-8-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+      ALTERNATE_SAXON_HOME: "/tmp/saxon"
+    steps:
+    - checkout
+    - run:
+        name: Download SaxonHE9-8-0-15J.zip
+        command: |-
+          mkdir -p /tmp/saxon
+          cd /tmp/saxon
+          curl -L -O https://sourceforge.net/projects/saxon/files/Saxon-HE/9.8/SaxonHE9-8-0-15J.zip
+          unzip SaxonHE9-8-0-15J.zip
+          rm -f SaxonHE9-8-0-15J.zip
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Install Code Climate Test Reporter
+        command: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+    - run:
+        name: Run the tests, and upload coverage data to Code Climate
+        command: |-
+          ./cc-test-reporter before-build
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          if [ $? -eq 0 ]; then ./cc-test-reporter format-coverage -t simplecov -o "cc-coverage-jar-loading-alt-saxon.json"; fi
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+          if [ $? -eq 0 ]; then ./cc-test-reporter format-coverage -t simplecov -o "cc-coverage-main-alt-saxon.json"; fi
+    - persist_to_workspace:
+        root: "~/project"
+        paths:
+        - cc-coverage*
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.12.0, JDK 8:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.12.0-8-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+    steps:
+    - checkout
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Install Code Climate Test Reporter
+        command: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+    - run:
+        name: Run the tests, and upload coverage data to Code Climate
+        command: |-
+          ./cc-test-reporter before-build
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          if [ $? -eq 0 ]; then ./cc-test-reporter format-coverage -t simplecov -o "cc-coverage-jar-loading.json"; fi
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+          if [ $? -eq 0 ]; then ./cc-test-reporter format-coverage -t simplecov -o "cc-coverage-main.json"; fi
+    - persist_to_workspace:
+        root: "~/project"
+        paths:
+        - cc-coverage*
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.12.0, JDK 11 Saxon HE 9.8:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.12.0-11-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+      ALTERNATE_SAXON_HOME: "/tmp/saxon"
+    steps:
+    - checkout
+    - run:
+        name: Download SaxonHE9-8-0-15J.zip
+        command: |-
+          mkdir -p /tmp/saxon
+          cd /tmp/saxon
+          curl -L -O https://sourceforge.net/projects/saxon/files/Saxon-HE/9.8/SaxonHE9-8-0-15J.zip
+          unzip SaxonHE9-8-0-15J.zip
+          rm -f SaxonHE9-8-0-15J.zip
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.12.0, JDK 11:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.12.0-11-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+    steps:
+    - checkout
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.12.0, JDK 13 Saxon HE 9.8:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.12.0-13-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+      ALTERNATE_SAXON_HOME: "/tmp/saxon"
+    steps:
+    - checkout
+    - run:
+        name: Download SaxonHE9-8-0-15J.zip
+        command: |-
+          mkdir -p /tmp/saxon
+          cd /tmp/saxon
+          curl -L -O https://sourceforge.net/projects/saxon/files/Saxon-HE/9.8/SaxonHE9-8-0-15J.zip
+          unzip SaxonHE9-8-0-15J.zip
+          rm -f SaxonHE9-8-0-15J.zip
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.12.0, JDK 13:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.12.0-13-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+    steps:
+    - checkout
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.13.0-SNAPSHOT-latest, JDK 8 Saxon HE 9.8:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.13.0-SNAPSHOT-latest-8-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+      ALTERNATE_SAXON_HOME: "/tmp/saxon"
+    steps:
+    - checkout
+    - run:
+        name: Download SaxonHE9-8-0-15J.zip
+        command: |-
+          mkdir -p /tmp/saxon
+          cd /tmp/saxon
+          curl -L -O https://sourceforge.net/projects/saxon/files/Saxon-HE/9.8/SaxonHE9-8-0-15J.zip
+          unzip SaxonHE9-8-0-15J.zip
+          rm -f SaxonHE9-8-0-15J.zip
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.13.0-SNAPSHOT-latest, JDK 8:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.13.0-SNAPSHOT-latest-8-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+    steps:
+    - checkout
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.13.0-SNAPSHOT-latest, JDK 11 Saxon HE 9.8:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.13.0-SNAPSHOT-latest-11-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+      ALTERNATE_SAXON_HOME: "/tmp/saxon"
+    steps:
+    - checkout
+    - run:
+        name: Download SaxonHE9-8-0-15J.zip
+        command: |-
+          mkdir -p /tmp/saxon
+          cd /tmp/saxon
+          curl -L -O https://sourceforge.net/projects/saxon/files/Saxon-HE/9.8/SaxonHE9-8-0-15J.zip
+          unzip SaxonHE9-8-0-15J.zip
+          rm -f SaxonHE9-8-0-15J.zip
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.13.0-SNAPSHOT-latest, JDK 11:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.13.0-SNAPSHOT-latest-11-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+    steps:
+    - checkout
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.13.0-SNAPSHOT-latest, JDK 13 Saxon HE 9.8:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.13.0-SNAPSHOT-latest-13-jdk-slim
+    environment:
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+      JRUBY_OPTS: "--dev --debug"
+      ALTERNATE_SAXON_HOME: "/tmp/saxon"
+    steps:
+    - checkout
+    - run:
+        name: Download SaxonHE9-8-0-15J.zip
+        command: |-
+          mkdir -p /tmp/saxon
+          cd /tmp/saxon
+          curl -L -O https://sourceforge.net/projects/saxon/files/Saxon-HE/9.8/SaxonHE9-8-0-15J.zip
+          unzip SaxonHE9-8-0-15J.zip
+          rm -f SaxonHE9-8-0-15J.zip
+    - run:
+        name: Bundle Install
+        command: bundle check || bundle install
+    - run:
+        name: Run the tests
+        command: |-
+          mkdir -p /tmp/test-results
+          VERIFY_SAXON_LAZY_LOADING=1 bundle exec rspec spec/jar_loading_spec.rb --options .rspec-jar-loading --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec-jar-loading.xml
+          rm -rf coverage
+          bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+    - store_test_results:
+        path: "/tmp/test-results"
+    - store_artifacts:
+        path: "/tmp/test-results"
+        destination: test-results
+  JRuby 9.2.13.0-SNAPSHOT-latest, JDK 13:
+    docker:
+    - image: fidothe/circleci:jruby-9.2.13.0-SNAPSHOT-latest-13-jdk-slim
     environment:
       BUNDLE_JOBS: 3
       BUNDLE_RETRY: 3
@@ -467,13 +998,31 @@ workflows:
     - JRuby 9.2.9.0, JDK 13
     - JRuby 9.1.17.0, JDK 8 Saxon HE 9.8
     - JRuby 9.1.17.0, JDK 8
-    - JRuby 9.2.10.0-SNAPSHOT-latest, JDK 8 Saxon HE 9.8
-    - JRuby 9.2.10.0-SNAPSHOT-latest, JDK 8
-    - JRuby 9.2.10.0-SNAPSHOT-latest, JDK 11 Saxon HE 9.8
-    - JRuby 9.2.10.0-SNAPSHOT-latest, JDK 11
-    - JRuby 9.2.10.0-SNAPSHOT-latest, JDK 13 Saxon HE 9.8
-    - JRuby 9.2.10.0-SNAPSHOT-latest, JDK 13
+    - JRuby 9.2.10.0, JDK 8 Saxon HE 9.8
+    - JRuby 9.2.10.0, JDK 8
+    - JRuby 9.2.10.0, JDK 11 Saxon HE 9.8
+    - JRuby 9.2.10.0, JDK 11
+    - JRuby 9.2.10.0, JDK 13 Saxon HE 9.8
+    - JRuby 9.2.10.0, JDK 13
+    - JRuby 9.2.11.1, JDK 8 Saxon HE 9.8
+    - JRuby 9.2.11.1, JDK 8
+    - JRuby 9.2.11.1, JDK 11 Saxon HE 9.8
+    - JRuby 9.2.11.1, JDK 11
+    - JRuby 9.2.11.1, JDK 13 Saxon HE 9.8
+    - JRuby 9.2.11.1, JDK 13
+    - JRuby 9.2.12.0, JDK 8 Saxon HE 9.8
+    - JRuby 9.2.12.0, JDK 8
+    - JRuby 9.2.12.0, JDK 11 Saxon HE 9.8
+    - JRuby 9.2.12.0, JDK 11
+    - JRuby 9.2.12.0, JDK 13 Saxon HE 9.8
+    - JRuby 9.2.12.0, JDK 13
+    - JRuby 9.2.13.0-SNAPSHOT-latest, JDK 8 Saxon HE 9.8
+    - JRuby 9.2.13.0-SNAPSHOT-latest, JDK 8
+    - JRuby 9.2.13.0-SNAPSHOT-latest, JDK 11 Saxon HE 9.8
+    - JRuby 9.2.13.0-SNAPSHOT-latest, JDK 11
+    - JRuby 9.2.13.0-SNAPSHOT-latest, JDK 13 Saxon HE 9.8
+    - JRuby 9.2.13.0-SNAPSHOT-latest, JDK 13
     - Report test coverage to Code Climate:
         requires:
-        - JRuby 9.2.9.0, JDK 8 Saxon HE 9.8
-        - JRuby 9.2.9.0, JDK 8
+        - JRuby 9.2.12.0, JDK 8 Saxon HE 9.8
+        - JRuby 9.2.12.0, JDK 8

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ task :circleci do
       end
     end
     def jruby_image_tags
-      %w{9.2.9.0 9.1.17.0 9.2.10.0-SNAPSHOT-latest}
+      %w{9.2.9.0 9.1.17.0 9.2.10.0 9.2.11.1 9.2.12.0 9.2.13.0-SNAPSHOT-latest}
     end
 
     def jdk_image_tags
@@ -51,7 +51,7 @@ task :circleci do
 
     def codeclimate_jobs
       (alt_saxon_urls.keys << nil).map { |alt_saxon_url|
-        ["9.2.9.0", "8-jdk-slim", alt_saxon_url]
+        ["9.2.12.0", "8-jdk-slim", alt_saxon_url]
       }
     end
 

--- a/lib/saxon/jruby_bug_6197_workaround.rb
+++ b/lib/saxon/jruby_bug_6197_workaround.rb
@@ -1,5 +1,5 @@
-if Java::net::sf::saxon::s9api.const_defined?(:AbstractXsltTransformer)
-  class Java::net::sf::saxon::s9api::AbstractXsltTransformer
+unless Java::net::sf::saxon::s9api::Xslt30Transformer.instance_methods.include?(:setInitialMode)
+  class Java::net::sf::saxon::s9api::Xslt30Transformer
     java_alias :setInitialMode, :setInitialMode, [Java::net::sf::saxon::s9api::QName]
   end
 end

--- a/lib/saxon/jruby_bug_6197_workaround.rb
+++ b/lib/saxon/jruby_bug_6197_workaround.rb
@@ -1,0 +1,5 @@
+if Java::net::sf::saxon::s9api.const_defined?(:AbstractXsltTransformer)
+  class Java::net::sf::saxon::s9api::AbstractXsltTransformer
+    java_alias :setInitialMode, :setInitialMode, [Java::net::sf::saxon::s9api::QName]
+  end
+end

--- a/lib/saxon/loader.rb
+++ b/lib/saxon/loader.rb
@@ -80,6 +80,7 @@ module Saxon
               end
             end
 
+            require_relative 'jruby_bug_6197_workaround'
             @saxon_loaded = true
             true
           end

--- a/lib/saxon/s9api.rb
+++ b/lib/saxon/s9api.rb
@@ -11,28 +11,28 @@ module Saxon
       # alternate location for them, if they don't want to use the bundled Saxon
       # HE
       def const_missing(name)
-        Saxon::Loader.load!
-        begin
-          const_set(name, imported_classes.const_get(name))
-        rescue NameError
-          msg = "uninitialized constant Saxon::S9API::#{name}"
-          e = NameError.new(msg, name)
-          raise e
-        end
+        CLASS_IMPORT_SEMAPHORE.synchronize {
+          return const_get(name) if const_defined?(name)
+          Saxon::Loader.load!
+          begin
+            const_set(name, imported_classes.const_get(name))
+          rescue NameError
+            msg = "uninitialized constant Saxon::S9API::#{name}"
+            e = NameError.new(msg, name)
+            raise e
+          end
+        }
       end
 
       private
 
       def imported_classes
-        return @imported_classes if instance_variable_defined?(:@imported_classes)
-        CLASS_IMPORT_SEMAPHORE.synchronize do
-          @imported_classes = Module.new {
-            include_package 'net.sf.saxon.s9api'
-            java_import Java::net.sf.saxon.Configuration
-            java_import Java::net.sf.saxon.lib.FeatureKeys
-            java_import Java::net.sf.saxon.lib.ParseOptions
-          }
-        end
+        @imported_classes ||= Module.new {
+          include_package 'net.sf.saxon.s9api'
+          java_import Java::net.sf.saxon.Configuration
+          java_import Java::net.sf.saxon.lib.FeatureKeys
+          java_import Java::net.sf.saxon.lib.ParseOptions
+        }
       end
     end
   end

--- a/lib/saxon/version.rb
+++ b/lib/saxon/version.rb
@@ -1,4 +1,4 @@
-require 'saxon/s9api'
+require 'saxon/version/library'
 
 module Saxon
   # Provides the saxon-rb and underlying Saxon library versions

--- a/lib/saxon/version.rb
+++ b/lib/saxon/version.rb
@@ -4,6 +4,6 @@ module Saxon
   # Provides the saxon-rb and underlying Saxon library versions
   module Version
     # The version of the saxon-rb gem (not of Saxon itself)
-    WRAPPER = "0.7.3"
+    WRAPPER = "0.8.0"
   end
 end

--- a/spec/jar_loading_spec.rb
+++ b/spec/jar_loading_spec.rb
@@ -11,7 +11,7 @@ if ENV['VERIFY_SAXON_LAZY_LOADING']
       require_targets = Pathname.glob("#{lib_path}/**/*.rb").map { |path|
         path.relative_path_from(lib_path).to_s.slice(0..-4)
       }.sort_by { |target| target.scan('/').size }.reject { |target|
-        %w{saxon-rb_jars}.include?(target)
+        %w{saxon-rb_jars saxon/jruby_bug_6197_workaround}.include?(target)
       }
 
       require_targets.each do |target|


### PR DESCRIPTION
Also, some minor loading improvements that prevent duplicate setting of constants in `Saxon::S9API` (which prevents warnings being issued).

Uses workaround suggested by @headius from jruby/jruby#6197.