### PR TITLE
Backport Saxon 10 version checker

### DIFF
--- a/lib/saxon/feature_flags/version.rb
+++ b/lib/saxon/feature_flags/version.rb
@@ -72,10 +72,7 @@ module Saxon
       #
       # @return [Saxon::Version::Library] the constraint version
       def constraint_version
-        @constraint_version ||= begin
-          components = version_string.split('.').map { |n| Integer(n, 10) }
-          Saxon::Version::Library.new(version_string, components, 'HE')
-        end
+        @constraint_version ||= Saxon::Version::Library.new(version_string, 'HE')
       end
 
       private

--- a/lib/saxon/version.rb
+++ b/lib/saxon/version.rb
@@ -4,6 +4,6 @@ module Saxon
   # Provides the saxon-rb and underlying Saxon library versions
   module Version
     # The version of the saxon-rb gem (not of Saxon itself)
-    WRAPPER = "0.8.1"
+    WRAPPER = "0.8.2"
   end
 end

--- a/lib/saxon/version/library.rb
+++ b/lib/saxon/version/library.rb
@@ -12,7 +12,7 @@ module Saxon
         Saxon::Loader.load!
 
         sv = Java::net.sf.saxon.Version
-        new(sv.getProductVersion, sv.getStructuredVersionNumber, sv.softwareEdition)
+        new(sv.getProductVersion, sv.softwareEdition)
       end
 
       include Comparable
@@ -27,9 +27,9 @@ module Saxon
       # @param version [String] the version string
       # @param components [Array<Integer>] the version components separated
       # @param edition [String, Symbol] the name of the Saxon edition (e.g. +:he+, +'HE'+)
-      def initialize(version, components, edition)
+      def initialize(version, edition)
         @version = version.dup.freeze
-        @components = components.dup.freeze
+        @components = version.split('.').map { |n| Integer(n, 10) }
         @edition = edition.downcase.to_sym
       end
 

--- a/spec/saxon/version/library_spec.rb
+++ b/spec/saxon/version/library_spec.rb
@@ -23,7 +23,7 @@ module Saxon
     end
 
     context "another version" do
-      subject { described_class.new("10.0", [10, 0], "EE") }
+      subject { described_class.new("10.0", "EE") }
 
       specify "returns the correct version string" do
         expect(subject.version).to eq("10.0")
@@ -39,10 +39,10 @@ module Saxon
     end
 
     describe "comparing versions" do
-      let(:v9_9_1_7) { described_class.new("9.9.1.7", [9, 9, 1, 7], "HE") }
-      let(:v9_10_0_0) { described_class.new("9.10.0.0", [9, 10, 0, 0], "HE") }
-      let(:v9_9_1_6) { described_class.new("9.9.1.6", [9, 9, 1, 6], "HE") }
-      let(:v10_0) { described_class.new("10.0", [10, 0], "HE") }
+      let(:v9_9_1_7) { described_class.new("9.9.1.7", "HE") }
+      let(:v9_10_0_0) { described_class.new("9.10.0.0", "HE") }
+      let(:v9_9_1_6) { described_class.new("9.9.1.6", "HE") }
+      let(:v10_0) { described_class.new("10.0", "HE") }
 
       context "greater-than" do
         specify "10.0 > 9.9" do
@@ -91,14 +91,14 @@ module Saxon
       end
 
       context "~> pessimistic version comparison" do
-        let(:v8_9_0_0) { described_class.new("8.9.0.0", [8,9,0,0], "HE") }
-        let(:v9_8_0_0) { described_class.new("9.8.0.0", [9,8,0,0], "HE") }
-        let(:v9_9_0_0) { described_class.new("9.9.0.0", [9,9,0,0], "HE") }
-        let(:v9_9_1_0) { described_class.new("9.9.1.0", [9,9,1,0], "HE") }
-        let(:v9_9_1) { described_class.new("9.9.1", [9,9,1], "HE") }
-        let(:v9_9) { described_class.new("9.9", [9,9], "HE") }
-        let(:v9_0) { described_class.new("9.0", [9,0], "HE") }
-        let(:v9_9_2_0) { described_class.new("9.9.2.0", [9,9,2,0], "HE") }
+        let(:v8_9_0_0) { described_class.new("8.9.0.0", "HE") }
+        let(:v9_8_0_0) { described_class.new("9.8.0.0", "HE") }
+        let(:v9_9_0_0) { described_class.new("9.9.0.0", "HE") }
+        let(:v9_9_1_0) { described_class.new("9.9.1.0", "HE") }
+        let(:v9_9_1) { described_class.new("9.9.1", "HE") }
+        let(:v9_9) { described_class.new("9.9", "HE") }
+        let(:v9_0) { described_class.new("9.0", "HE") }
+        let(:v9_9_2_0) { described_class.new("9.9.2.0", "HE") }
 
         context "passes" do
           specify "9.9.1.6 ~> 9.9.1.0" do


### PR DESCRIPTION
the only (obvious) incompatibility with Saxon 10 was the change from 4-part to 2-part version numbers, which broke the feature flag code. This change makes that code work, and should allow Saxon 10 to be safely used with saxon-rb. Uses beyond the usual - beyond things we have wrapper classes for - may have some problems, but it doesn't look like it from the changelog.

Anyway, this minor release should allow people to use their own copy of Saxon 10 while I continue to work on a bundled release I'm 100% happy with